### PR TITLE
Add new labels to configuration files

### DIFF
--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -13,9 +13,12 @@ caseSensitive: true
 # Explicit keyword mappings to labels. Form of match:label. Required.
 labelMappings:
   "part:docs": "part:docs"
+  "part:grid": "part:grid"
+  "part:location": "part:location"
+  "part:market": "part:market"
+  "part:metrics": "part:metrics"
+  "part:microgrid": "part:microgrid"
+  "part:pagination": "part:pagination"
   "part:tests": "part:tests"
   "part:tooling": "part:tooling"
   "part:❓": "part:❓"
-  # TODO(cookiecutter): Add other parts
-  # Please have in mind that that the part:xxx labels need to
-  # be created in the GitHub repository.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,30 @@
   - "examples/**"
   - LICENSE
 
+"part:grid":
+  - "src/frequenz/client/common/grid*"
+  - "src/frequenz/client/common/grid/**"
+
+"part:location":
+  - "src/frequenz/client/common/location*"
+  - "src/frequenz/client/common/location/**"
+
+"part:market":
+  - "src/frequenz/client/common/market*"
+  - "src/frequenz/client/common/market/**"
+
+"part:metrics":
+  - "src/frequenz/client/common/metrics*"
+  - "src/frequenz/client/common/metrics/**"
+
+"part:microgrid":
+  - "src/frequenz/client/common/microgrid*"
+  - "src/frequenz/client/common/microgrid/**"
+
+"part:pagination":
+  - "src/frequenz/client/common/pagination*"
+  - "src/frequenz/client/common/pagination/**"
+
 "part:tests":
   - "**/conftest.py"
   - "tests/**"


### PR DESCRIPTION
These new labels were added to the repository, so we configure the different tools to use them.

This assumes the directory structure will match the one in the `frequenz-api-common` repository.
