### PR TITLE
Page size and token no longer optional in pagination Params

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+Update of the Pagination `Params` data class.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* Pagination `Params` has been changed such that the `page_size` and `page_token` fields are now no longer optional.
 
 ## New Features
 

--- a/src/frequenz/client/common/pagination/__init__.py
+++ b/src/frequenz/client/common/pagination/__init__.py
@@ -19,10 +19,10 @@ from frequenz.api.common.v1.pagination.pagination_params_pb2 import PaginationPa
 class Params:
     """Parameters for paginating list requests."""
 
-    page_size: int | None = None
+    page_size: int
     """The maximum number of results to be returned per request."""
 
-    page_token: str | None = None
+    page_token: str
     """The token identifying a specific page of the list results."""
 
     @classmethod


### PR DESCRIPTION
Removed the initialisation to None for the parameters `page_size` and `page_token` in pagination `Params` as they are no longer optional due to the change in https://github.com/frequenz-floss/frequenz-api-common/pull/232

This PR fixes the CI failures in #44 