### PR TITLE
Remove prefixes from `Event` enum values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Summary
 
+This is the same release as v0.3.5 but with prefixes in `Event` enum values removed. The v0.3.5 release will be yanked from PyPI and it should not be used.
 
 ## Upgrading
 

--- a/src/frequenz/client/common/streaming/__init__.py
+++ b/src/frequenz/client/common/streaming/__init__.py
@@ -13,14 +13,14 @@ from frequenz.api.common.v1alpha8.streaming import event_pb2 as PBEvent
 class Event(Enum):
     """Enum representing the type of streaming event."""
 
-    EVENT_UNSPECIFIED = PBEvent.EVENT_UNSPECIFIED
+    UNSPECIFIED = PBEvent.EVENT_UNSPECIFIED
     """Unspecified event type."""
 
-    EVENT_CREATED = PBEvent.EVENT_CREATED
+    CREATED = PBEvent.EVENT_CREATED
     """Event when a new resource is created."""
 
-    EVENT_UPDATED = PBEvent.EVENT_UPDATED
+    UPDATED = PBEvent.EVENT_UPDATED
     """Event when an existing resource is updated."""
 
-    EVENT_DELETED = PBEvent.EVENT_DELETED
+    DELETED = PBEvent.EVENT_DELETED
     """Event when a resource is deleted."""


### PR DESCRIPTION
This is a breaking change, but the v0.3.5 release is not yet used, so we will yank it from PyPI and release this as v0.3.6.
