### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Manage
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'all'
+          auto-merge: 'true'
+          merge-method: 'merge'
+          add-label: 'auto-merged'


### PR DESCRIPTION
## Summary
- Add GitHub workflow to automatically approve and merge Dependabot PRs
- Uses `merge` method for clean commit history