### PR TITLE
Migrate to frequenz-floss dependabot-auto-approve action

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Manage
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'all'
+          auto-merge: 'true'
+          merge-method: 'merge'
+          add-label: 'auto-merged'

--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: ad/dependabot-auto-approve@v1
+      - uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
         with:
           dependency-type: 'all'
           auto-merge: 'true'


### PR DESCRIPTION
Use commit hash instead of version tag for better security and reproducibility.