### PR TITLE
Add conversion for the remaining `v1alpha8` enums

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,11 +6,12 @@
 
 ## Upgrading
 
-- Converting `Metric` enums from/to protobuf directly is not supported anymore, you need to use explicit conversion functions, like the ones in `frequenz.client.common.metrics.proto.v1alpha8`.
+- Converting v1alpha8-backed enums from/to protobuf directly is not supported anymore, you need to use explicit conversion functions in `frequenz.client.common.metrics.proto.v1alpha8`, `frequenz.client.common.streaming.proto.v1alpha8`, or `frequenz.client.common.microgrid.electrical_components.proto.v1alpha8`.
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Added v1alpha8 conversion functions for `MetricConnectionCategory`, `Event`, and electrical component enums.
+- Added a new `frequenz.client.common.test` package with a `enum_parity` module providing a convenient class to test for protobuf-Python enum parity.
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.13.0, < 5",
-  "frequenz-api-common >= 0.8.0, < 1",
+  "frequenz-api-common >= 0.8.4, < 1",
   "frequenz-core >= 1.0.2, < 2",
-  "protobuf >= 6.33.1, < 8",
+  "protobuf >= 6.33.6, < 8",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/client/common/metrics/_sample.py
+++ b/src/frequenz/client/common/metrics/_sample.py
@@ -9,8 +9,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import assert_never
 
-from frequenz.api.common.v1alpha8.metrics import metrics_pb2
-
 from ._bounds import Bounds
 from ._metric import Metric
 
@@ -72,28 +70,28 @@ class AggregatedMetricValue:
 class MetricConnectionCategory(enum.Enum):
     """The categories of connections from which metrics can be obtained."""
 
-    UNSPECIFIED = metrics_pb2.METRIC_CONNECTION_CATEGORY_UNSPECIFIED
+    UNSPECIFIED = 0
     """The connection category was not specified (do not use)."""
 
-    OTHER = metrics_pb2.METRIC_CONNECTION_CATEGORY_OTHER
+    OTHER = 1
     """A generic connection for metrics that do not fit into any other category."""
 
-    BATTERY = metrics_pb2.METRIC_CONNECTION_CATEGORY_BATTERY
+    BATTERY = 2
     """A connection to a metric representing a battery."""
 
-    PV = metrics_pb2.METRIC_CONNECTION_CATEGORY_PV
+    PV = 3
     """A connection to a metric representing a PV (photovoltaic) array or string."""
 
-    AMBIENT = metrics_pb2.METRIC_CONNECTION_CATEGORY_AMBIENT
+    AMBIENT = 10
     """A connection to a metric representing ambient conditions."""
 
-    CABINET = metrics_pb2.METRIC_CONNECTION_CATEGORY_CABINET
+    CABINET = 11
     """A connection to a metric representing a cabinet or an enclosure."""
 
-    HEATSINK = metrics_pb2.METRIC_CONNECTION_CATEGORY_HEATSINK
+    HEATSINK = 12
     """A connection to a metric representing a heatsink."""
 
-    TRANSFORMER = metrics_pb2.METRIC_CONNECTION_CATEGORY_TRANSFORMER
+    TRANSFORMER = 13
     """A connection to a metric representing a transformer."""
 
 

--- a/src/frequenz/client/common/metrics/proto/_sample.py
+++ b/src/frequenz/client/common/metrics/proto/_sample.py
@@ -17,6 +17,7 @@ from .._sample import (
     MetricSample,
 )
 from ._bounds import bounds_from_proto
+from .v1alpha8 import metric_from_proto
 
 
 def aggregated_metric_sample_from_proto(
@@ -86,7 +87,7 @@ def metric_sample_from_proto_with_issues(
     """
     sample_time = datetime_from_proto(message.sample_time)
 
-    metric = enum_from_proto(message.metric, Metric)
+    metric = metric_from_proto(message.metric)
 
     value: float | AggregatedMetricValue | None = None
     if message.HasField("value"):

--- a/src/frequenz/client/common/metrics/proto/_sample.py
+++ b/src/frequenz/client/common/metrics/proto/_sample.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 
 from frequenz.api.common.v1alpha8.metrics import bounds_pb2, metrics_pb2
 
-from ...proto import datetime_from_proto, enum_from_proto
+from ...proto import datetime_from_proto
 from .._bounds import Bounds
 from .._metric import Metric
 from .._sample import (
@@ -17,7 +17,7 @@ from .._sample import (
     MetricSample,
 )
 from ._bounds import bounds_from_proto
-from .v1alpha8 import metric_from_proto
+from .v1alpha8 import metric_connection_category_from_proto, metric_from_proto
 
 
 def aggregated_metric_sample_from_proto(
@@ -55,7 +55,7 @@ def metric_connection_from_proto_with_issues(
     Returns:
         The resulting `MetricConnection` object.
     """
-    category = enum_from_proto(message.category, MetricConnectionCategory)
+    category = metric_connection_category_from_proto(message.category)
 
     match category:
         case MetricConnectionCategory.UNSPECIFIED:

--- a/src/frequenz/client/common/metrics/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/metrics/proto/v1alpha8/__init__.py
@@ -1,11 +1,17 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Conversion of Metric from/to protobuf v1alpha8."""
+"""Conversion of metrics enums from/to protobuf v1alpha8."""
 
 from ._metric import metric_from_proto, metric_to_proto
+from ._metric_connection_category import (
+    metric_connection_category_from_proto,
+    metric_connection_category_to_proto,
+)
 
 __all__ = [
+    "metric_connection_category_from_proto",
+    "metric_connection_category_to_proto",
     "metric_from_proto",
     "metric_to_proto",
 ]

--- a/src/frequenz/client/common/metrics/proto/v1alpha8/_metric_connection_category.py
+++ b/src/frequenz/client/common/metrics/proto/v1alpha8/_metric_connection_category.py
@@ -1,0 +1,38 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of MetricConnectionCategory to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.metrics import metrics_pb2
+
+from ....proto import enum_from_proto
+from ..._sample import MetricConnectionCategory
+
+
+def metric_connection_category_from_proto(
+    message: metrics_pb2.MetricConnectionCategory.ValueType,
+) -> MetricConnectionCategory | int:
+    """Convert a protobuf MetricConnectionCategory enum value to an enum member.
+
+    Args:
+        message: A protobuf MetricConnectionCategory enum value.
+
+    Returns:
+        The corresponding MetricConnectionCategory enum member, or the raw `int` if
+            the protobuf value is not recognized.
+    """
+    return enum_from_proto(message, MetricConnectionCategory)
+
+
+def metric_connection_category_to_proto(
+    category: MetricConnectionCategory,
+) -> metrics_pb2.MetricConnectionCategory.ValueType:
+    """Convert a MetricConnectionCategory enum member to a protobuf enum value.
+
+    Args:
+        category: A MetricConnectionCategory enum member.
+
+    Returns:
+        The corresponding protobuf MetricConnectionCategory enum value.
+    """
+    return metrics_pb2.MetricConnectionCategory.ValueType(category.value)

--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -33,60 +33,50 @@ class ElectricalComponentId(BaseId, str_prefix="CID"):
 class ElectricalComponentCategory(enum.Enum):
     """Possible types of microgrid electrical component."""
 
-    UNSPECIFIED = (
-        PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_UNSPECIFIED
-    )
+    UNSPECIFIED = 0
     """An unknown component category.
 
     Useful for error handling, and marking unknown components in
     a list of components with otherwise known categories.
     """
 
-    GRID_CONNECTION_POINT = (
-        PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT
-    )
+    GRID_CONNECTION_POINT = 1
     """The point where the local microgrid is connected to the grid."""
 
-    METER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_METER
+    METER = 2
     """A meter, for measuring electrical metrics, e.g., current, voltage, etc."""
 
-    INVERTER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_INVERTER
+    INVERTER = 3
     """An electricity generator, with batteries or solar energy."""
 
-    CONVERTER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_CONVERTER
+    CONVERTER = 4
     """An electricity converter, e.g., a DC-DC converter."""
 
-    BATTERY = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_BATTERY
+    BATTERY = 5
     """A storage system for electrical energy, used by inverters."""
 
-    EV_CHARGER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_EV_CHARGER
+    EV_CHARGER = 6
     """A station for charging electrical vehicles."""
 
-    CRYPTO_MINER = (
-        PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_CRYPTO_MINER
-    )
+    CRYPTO_MINER = 14
     """A device for mining cryptocurrencies."""
 
-    ELECTROLYZER = (
-        PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_ELECTROLYZER
-    )
+    ELECTROLYZER = 10
     """A device for splitting water into hydrogen and oxygen using electricity."""
 
-    CHP = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_CHP
+    CHP = 9
     """A heat and power combustion plant (CHP stands for combined heat and power)."""
 
-    BREAKER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_BREAKER
+    BREAKER = 7
     """A relay, used for switching electrical circuits on and off."""
 
-    PRECHARGER = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_PRECHARGER
+    PRECHARGER = 8
     """A precharger, used for preparing electrical circuits for switching on."""
 
-    POWER_TRANSFORMER = (
-        PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_POWER_TRANSFORMER
-    )
+    POWER_TRANSFORMER = 11
     """A transformer, used for changing the voltage of electrical circuits."""
 
-    HVAC = PBElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_HVAC
+    HVAC = 12
     """A heating, ventilation, and air conditioning (HVAC) system."""
 
     @classmethod
@@ -123,102 +113,72 @@ class ElectricalComponentCategory(enum.Enum):
 class ElectricalComponentStateCode(enum.Enum):
     """All possible states of a microgrid electrical component."""
 
-    UNSPECIFIED = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_UNSPECIFIED
-    )
+    UNSPECIFIED = 0
     """Default value when the component state is not explicitly set."""
 
-    UNKNOWN = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_UNKNOWN
+    UNKNOWN = 1
     """State when the component is in an unknown or undefined condition.
 
     This is used when the sender is unable to classify the component into any
     other state.
     """
 
-    UNAVAILABLE = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_UNAVAILABLE
-    )
+    UNAVAILABLE = 2
     """State when the component is not available for use."""
 
-    SWITCHING_OFF = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_SWITCHING_OFF
-    )
+    SWITCHING_OFF = 3
     """State when the component is in the process of switching off."""
 
-    OFF = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_OFF
+    OFF = 4
     """State when the component has successfully switched off."""
 
-    SWITCHING_ON = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_SWITCHING_ON
-    )
+    SWITCHING_ON = 5
     """State when the component is in the process of switching on from an off state."""
 
-    STANDBY = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_STANDBY
+    STANDBY = 6
     """State when the component is in standby mode, and not immediately ready for operation."""
 
-    READY = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_READY
+    READY = 7
     """State when the component is fully operational and ready for use."""
 
-    CHARGING = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_CHARGING
+    CHARGING = 8
     """State when the component is actively consuming energy."""
 
-    DISCHARGING = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_DISCHARGING
-    )
+    DISCHARGING = 9
     """State when the component is actively producing or releasing energy."""
 
-    ERROR = PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_ERROR
+    ERROR = 10
     """State when the component is in an error state and may need attention."""
 
-    EV_CHARGING_CABLE_UNPLUGGED = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_UNPLUGGED
-    )
+    EV_CHARGING_CABLE_UNPLUGGED = 20
     """The Electric Vehicle (EV) charging cable is unplugged from the charging station."""
 
-    EV_CHARGING_CABLE_PLUGGED_AT_STATION = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_STATION  # noqa: E501
-    )
+    EV_CHARGING_CABLE_PLUGGED_AT_STATION = 21
     """The EV charging cable is plugged into the charging station."""
 
-    EV_CHARGING_CABLE_PLUGGED_AT_EV = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_EV  # noqa: E501
-    )
+    EV_CHARGING_CABLE_PLUGGED_AT_EV = 22
     """The EV charging cable is plugged into the vehicle."""
 
-    EV_CHARGING_CABLE_LOCKED_AT_STATION = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_STATION  # noqa: E501
-    )
+    EV_CHARGING_CABLE_LOCKED_AT_STATION = 23
     """The EV charging cable is locked at the charging station end, indicating
     readiness for charging."""
 
-    EV_CHARGING_CABLE_LOCKED_AT_EV = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_EV  # noqa: E501
-    )
+    EV_CHARGING_CABLE_LOCKED_AT_EV = 24
     """The EV charging cable is locked at the vehicle end, indicating that charging is active."""
 
-    RELAY_OPEN = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_RELAY_OPEN
-    )
+    RELAY_OPEN = 30
     """The relay is in an open state, meaning no current can flow through."""
 
-    RELAY_CLOSED = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_RELAY_CLOSED
-    )
+    RELAY_CLOSED = 31
     """The relay is in a closed state, allowing current to flow."""
 
-    PRECHARGER_OPEN = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_OPEN
-    )
+    PRECHARGER_OPEN = 40
     """The precharger circuit is open, meaning it's not currently active."""
 
-    PRECHARGER_PRECHARGING = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_PRECHARGING
-    )
+    PRECHARGER_PRECHARGING = 41
     """The precharger is in a precharging state, preparing the main circuit for activation."""
 
-    PRECHARGER_CLOSED = (
-        PBElectricalComponentStateCode.ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_CLOSED
-    )
+    PRECHARGER_CLOSED = 42
     """The precharger circuit is closed, allowing full current to flow to the main circuit."""
 
     @classmethod
@@ -255,188 +215,120 @@ class ElectricalComponentStateCode(enum.Enum):
 class ElectricalComponentDiagnosticCode(enum.Enum):
     """All diagnostics that can occur across electrical component categories."""
 
-    UNSPECIFIED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNSPECIFIED
-    )
+    UNSPECIFIED = 0
     """Default value. No specific error is specified."""
 
-    UNKNOWN = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNKNOWN
-    )
+    UNKNOWN = 1
     """The component is reporting an unknown or an undefined error, and the sender
     cannot parse the component error to any of the variants below."""
 
-    SWITCH_ON_FAULT = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_SWITCH_ON_FAULT
-    )
+    SWITCH_ON_FAULT = 2
     """Error indicating that the component could not be switched on."""
 
-    UNDERVOLTAGE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNDERVOLTAGE
-    )
+    UNDERVOLTAGE = 3
     """Error indicating that the component is operating under the minimum rated
     voltage."""
 
-    OVERVOLTAGE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_OVERVOLTAGE
-    )
+    OVERVOLTAGE = 4
     """Error indicating that the component is operating over the maximum rated
     voltage."""
 
-    OVERCURRENT = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_OVERCURRENT
-    )
+    OVERCURRENT = 5
     """Error indicating that the component is drawing more current than the
     maximum rated value."""
 
-    OVERCURRENT_CHARGING = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_OVERCURRENT_CHARGING  # noqa: E501
-    )
+    OVERCURRENT_CHARGING = 6
     """Error indicating that the component's consumption current is over the
     maximum rated value during charging."""
 
-    OVERCURRENT_DISCHARGING = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_OVERCURRENT_DISCHARGING  # noqa: E501
-    )
+    OVERCURRENT_DISCHARGING = 7
     """Error indicating that the component's production current is over the
     maximum rated value during discharging."""
 
-    OVERTEMPERATURE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_OVERTEMPERATURE
-    )
+    OVERTEMPERATURE = 8
     """Error indicating that the component is operating over the maximum rated
     temperature."""
 
-    UNDERTEMPERATURE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNDERTEMPERATURE
-    )
+    UNDERTEMPERATURE = 9
     """Error indicating that the component is operating under the minimum rated
     temperature."""
 
-    HIGH_HUMIDITY = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HIGH_HUMIDITY
-    )
+    HIGH_HUMIDITY = 10
     """Error indicating that the component is exposed to high humidity levels over
     the maximum rated value."""
 
-    FUSE_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_FUSE_ERROR
-    )
+    FUSE_ERROR = 11
     """Error indicating that the component's fuse has blown."""
 
-    PRECHARGE_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PRECHARGE_ERROR
-    )
+    PRECHARGE_ERROR = 12
     """Error indicating that the component's precharge unit has failed."""
 
-    PLAUSIBILITY_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PLAUSIBILITY_ERROR
-    )
+    PLAUSIBILITY_ERROR = 13
     """Error indicating plausibility issues within the system involving this
     component."""
 
-    EV_UNEXPECTED_PILOT_FAILURE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_UNEXPECTED_PILOT_FAILURE  # noqa: E501
-    )
+    EV_UNEXPECTED_PILOT_FAILURE = 40
     """Error indicating unexpected pilot failure in an electric vehicle (EV)
     component."""
 
-    FAULT_CURRENT = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_FAULT_CURRENT
-    )
+    FAULT_CURRENT = 14
     """Error indicating fault current detected in the component."""
 
-    SHORT_CIRCUIT = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_SHORT_CIRCUIT
-    )
+    SHORT_CIRCUIT = 15
     """Error indicating a short circuit detected in the component."""
 
-    CONFIG_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_CONFIG_ERROR
-    )
+    CONFIG_ERROR = 16
     """Error indicating a configuration error related to the component."""
 
-    ILLEGAL_COMPONENT_STATE_CODE_REQUESTED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_ILLEGAL_COMPONENT_STATE_CODE_REQUESTED  # noqa: E501
-    )
+    ILLEGAL_COMPONENT_STATE_CODE_REQUESTED = 17
     """Error indicating an illegal state requested for the component."""
 
-    HARDWARE_INACCESSIBLE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HARDWARE_INACCESSIBLE  # noqa: E501
-    )
+    HARDWARE_INACCESSIBLE = 18
     """Error indicating that the hardware of the component is inaccessible."""
 
-    INTERNAL = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_INTERNAL
-    )
+    INTERNAL = 19
     """Error indicating an internal error within the component."""
 
-    UNAUTHORIZED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNAUTHORIZED
-    )
+    UNAUTHORIZED = 20
     """Error indicating that the component is unauthorized to perform the
     last requested action."""
 
-    EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION  # noqa: E501
-    )
+    EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = 41
     """Error indicating electric vehicle (EV) cable was abruptly unplugged from
     the charging station."""
 
-    EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_EV  # noqa: E501
-    )
+    EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 42
     """Error indicating electric vehicle (EV) cable was abruptly unplugged from
     the vehicle."""
 
-    EV_CHARGING_CABLE_LOCK_FAILED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_LOCK_FAILED  # noqa: E501
-    )
+    EV_CHARGING_CABLE_LOCK_FAILED = 43
     """Error indicating electric vehicle (EV) cable lock failure."""
 
-    EV_CHARGING_CABLE_INVALID = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_INVALID  # noqa: E501
-    )
+    EV_CHARGING_CABLE_INVALID = 44
     """Error indicating an invalid electric vehicle (EV) cable."""
 
-    EV_CONSUMER_INCOMPATIBLE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CONSUMER_INCOMPATIBLE  # noqa: E501
-    )
+    EV_CONSUMER_INCOMPATIBLE = 45
     """Error indicating an incompatible electric vehicle (EV) plug."""
 
-    BATTERY_IMBALANCE = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_IMBALANCE
-    )
+    BATTERY_IMBALANCE = 50
     """Error indicating a battery system imbalance."""
 
-    BATTERY_LOW_SOH = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_LOW_SOH
-    )
+    BATTERY_LOW_SOH = 51
     """Error indicating a low state of health (SOH) detected in the battery."""
 
-    BATTERY_BLOCK_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_BLOCK_ERROR
-    )
+    BATTERY_BLOCK_ERROR = 52
     """Error indicating a battery block error."""
 
-    BATTERY_CONTROLLER_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_CONTROLLER_ERROR  # noqa: E501
-    )
+    BATTERY_CONTROLLER_ERROR = 53
     """Error indicating a battery controller error."""
 
-    BATTERY_RELAY_ERROR = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_RELAY_ERROR
-    )
+    BATTERY_RELAY_ERROR = 54
     """Error indicating a battery relay error."""
 
-    BATTERY_CALIBRATION_NEEDED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_CALIBRATION_NEEDED  # noqa: E501
-    )
+    BATTERY_CALIBRATION_NEEDED = 56
     """Error indicating that battery calibration is needed."""
 
-    RELAY_CYCLE_LIMIT_REACHED = (
-        PBElectricalComponentDiagnosticCode.ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_RELAY_CYCLE_LIMIT_REACHED  # noqa: E501
-    )
+    RELAY_CYCLE_LIMIT_REACHED = 60
     """Error indicating that the relays have been cycled for the maximum number of
     times."""
 

--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -118,38 +118,38 @@ class ElectricalComponentStateCode(enum.Enum):
     """Default value when the component state is not explicitly set."""
 
     UNKNOWN = 1
-    """State when the component is in an unknown or undefined condition.
+    """The component is in an unknown or undefined condition.
 
     This is used when the sender is unable to classify the component into any
     other state.
     """
 
     UNAVAILABLE = 2
-    """State when the component is not available for use."""
+    """The component is not available for use."""
 
     SWITCHING_OFF = 3
-    """State when the component is in the process of switching off."""
+    """The component is in the process of switching off."""
 
     OFF = 4
-    """State when the component has successfully switched off."""
+    """The component has successfully switched off."""
 
     SWITCHING_ON = 5
-    """State when the component is in the process of switching on from an off state."""
+    """The component is in the process of switching on from an off state."""
 
     STANDBY = 6
-    """State when the component is in standby mode, and not immediately ready for operation."""
+    """The component is in standby mode, and not immediately ready for operation."""
 
     READY = 7
-    """State when the component is fully operational and ready for use."""
+    """The component is fully operational and ready for use."""
 
     CHARGING = 8
-    """State when the component is actively consuming energy."""
+    """The component is actively consuming energy."""
 
     DISCHARGING = 9
-    """State when the component is actively producing or releasing energy."""
+    """The component is actively producing or releasing energy."""
 
     ERROR = 10
-    """State when the component is in an error state and may need attention."""
+    """The component is in an error state and may need attention."""
 
     EV_CHARGING_CABLE_UNPLUGGED = 20
     """The Electric Vehicle (EV) charging cable is unplugged from the charging station."""
@@ -161,8 +161,7 @@ class ElectricalComponentStateCode(enum.Enum):
     """The EV charging cable is plugged into the vehicle."""
 
     EV_CHARGING_CABLE_LOCKED_AT_STATION = 23
-    """The EV charging cable is locked at the charging station end, indicating
-    readiness for charging."""
+    """The EV charging cable is locked at the charging station end, ready for charging."""
 
     EV_CHARGING_CABLE_LOCKED_AT_EV = 24
     """The EV charging cable is locked at the vehicle end, indicating that charging is active."""
@@ -221,118 +220,106 @@ class ElectricalComponentDiagnosticCode(enum.Enum):
     """Default value. No specific error is specified."""
 
     UNKNOWN = 1
-    """The component is reporting an unknown or an undefined error, and the sender
-    cannot parse the component error to any of the variants below."""
+    """The component is reporting an unknown or an undefined error.
+
+    The sender cannot parse the component error to any of the variants below.
+    """
 
     SWITCH_ON_FAULT = 2
-    """Error indicating that the component could not be switched on."""
+    """The component could not be switched on."""
 
     UNDERVOLTAGE = 3
-    """Error indicating that the component is operating under the minimum rated
-    voltage."""
+    """The component is operating under the minimum rated voltage."""
 
     OVERVOLTAGE = 4
-    """Error indicating that the component is operating over the maximum rated
-    voltage."""
+    """The component is operating over the maximum rated voltage."""
 
     OVERCURRENT = 5
-    """Error indicating that the component is drawing more current than the
-    maximum rated value."""
+    """The component is drawing more current than the maximum rated value."""
 
     OVERCURRENT_CHARGING = 6
-    """Error indicating that the component's consumption current is over the
-    maximum rated value during charging."""
+    """The component's consumption current is over the maximum rated value during charging."""
 
     OVERCURRENT_DISCHARGING = 7
-    """Error indicating that the component's production current is over the
-    maximum rated value during discharging."""
+    """The component's production current is over the maximum rated value during discharging."""
 
     OVERTEMPERATURE = 8
-    """Error indicating that the component is operating over the maximum rated
-    temperature."""
+    """The component is operating over the maximum rated temperature."""
 
     UNDERTEMPERATURE = 9
-    """Error indicating that the component is operating under the minimum rated
-    temperature."""
+    """The component is operating under the minimum rated temperature."""
 
     HIGH_HUMIDITY = 10
-    """Error indicating that the component is exposed to high humidity levels over
-    the maximum rated value."""
+    """The component is exposed to high humidity levels over the maximum rated value."""
 
     FUSE_ERROR = 11
-    """Error indicating that the component's fuse has blown."""
+    """The component's fuse has blown."""
 
     PRECHARGE_ERROR = 12
-    """Error indicating that the component's precharge unit has failed."""
+    """The component's precharge unit has failed."""
 
     PLAUSIBILITY_ERROR = 13
-    """Error indicating plausibility issues within the system involving this
-    component."""
+    """Plausibility issues within the system involving this component."""
 
     EV_UNEXPECTED_PILOT_FAILURE = 40
-    """Error indicating unexpected pilot failure in an electric vehicle (EV)
-    component."""
+    """Unexpected pilot failure in an electric vehicle (EV) component."""
 
     FAULT_CURRENT = 14
-    """Error indicating fault current detected in the component."""
+    """Fault current detected in the component."""
 
     SHORT_CIRCUIT = 15
-    """Error indicating a short circuit detected in the component."""
+    """Short circuit detected in the component."""
 
     CONFIG_ERROR = 16
-    """Error indicating a configuration error related to the component."""
+    """Configuration error related to the component."""
 
     ILLEGAL_COMPONENT_STATE_CODE_REQUESTED = 17
-    """Error indicating an illegal state requested for the component."""
+    """An illegal state was requested for the component."""
 
     HARDWARE_INACCESSIBLE = 18
-    """Error indicating that the hardware of the component is inaccessible."""
+    """The hardware of the component is inaccessible."""
 
     INTERNAL = 19
-    """Error indicating an internal error within the component."""
+    """An internal error within the component."""
 
     UNAUTHORIZED = 20
-    """Error indicating that the component is unauthorized to perform the
-    last requested action."""
+    """The component is unauthorized to perform the last requested action."""
 
     EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = 41
-    """Error indicating electric vehicle (EV) cable was abruptly unplugged from
-    the charging station."""
+    """Electric vehicle (EV) cable was abruptly unplugged from the charging station."""
 
     EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 42
-    """Error indicating electric vehicle (EV) cable was abruptly unplugged from
-    the vehicle."""
+    """Electric vehicle (EV) cable was abruptly unplugged from the vehicle."""
 
     EV_CHARGING_CABLE_LOCK_FAILED = 43
-    """Error indicating electric vehicle (EV) cable lock failure."""
+    """Electric vehicle (EV) cable lock failure."""
 
     EV_CHARGING_CABLE_INVALID = 44
-    """Error indicating an invalid electric vehicle (EV) cable."""
+    """Invalid electric vehicle (EV) cable."""
 
     EV_CONSUMER_INCOMPATIBLE = 45
-    """Error indicating an incompatible electric vehicle (EV) plug."""
+    """Incompatible electric vehicle (EV) plug."""
 
     BATTERY_IMBALANCE = 50
-    """Error indicating a battery system imbalance."""
+    """Battery system imbalance detected."""
 
     BATTERY_LOW_SOH = 51
-    """Error indicating a low state of health (SOH) detected in the battery."""
+    """Low state of health (SOH) detected in the battery."""
 
     BATTERY_BLOCK_ERROR = 52
-    """Error indicating a battery block error."""
+    """Battery block error detected."""
 
     BATTERY_CONTROLLER_ERROR = 53
-    """Error indicating a battery controller error."""
+    """Battery controller error detected."""
 
     BATTERY_RELAY_ERROR = 54
-    """Error indicating a battery relay error."""
+    """Battery relay error detected."""
 
     BATTERY_CALIBRATION_NEEDED = 56
-    """Error indicating that battery calibration is needed."""
+    """Battery calibration is needed."""
 
     RELAY_CYCLE_LIMIT_REACHED = 60
-    """Error indicating that the relays have been cycled for the maximum number of
-    times."""
+    """The relays have been cycled for the maximum number of times."""
 
     @classmethod
     @deprecated(

--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -79,6 +79,24 @@ class ElectricalComponentCategory(enum.Enum):
     HVAC = 12
     """A heating, ventilation, and air conditioning (HVAC) system."""
 
+    PLC = 13
+    """A programmable logic controller (PLC)."""
+
+    STATIC_TRANSFER_SWITCH = 15
+    """A static transfer switch, used for switching between power sources."""
+
+    UNINTERRUPTIBLE_POWER_SUPPLY = 16
+    """An uninterruptible power supply (UPS), used to provide backup power."""
+
+    CAPACITOR_BANK = 17
+    """A capacitor bank, used for power factor correction and reactive power compensation."""
+
+    WIND_TURBINE = 18
+    """A wind turbine, used to generate electricity from wind energy."""
+
+    STEAM_BOILER = 19
+    """A steam boiler, used to generate steam for heating or industrial processes."""
+
     @classmethod
     @deprecated(
         "frequenz.client.common.microgrid.electrical_components."
@@ -285,6 +303,48 @@ class ElectricalComponentDiagnosticCode(enum.Enum):
     UNAUTHORIZED = 20
     """The component is unauthorized to perform the last requested action."""
 
+    EXCESS_LEAKAGE_CURRENT = 21
+    """Excess leakage current was detected in the component."""
+
+    LOW_SYSTEM_INSULATION_RESISTANCE = 22
+    """Low system insulation resistance detected in the component."""
+
+    GROUND_FAULT = 23
+    """Ground fault detected in the component."""
+
+    ARC_FAULT = 24
+    """Arc fault detected in the component."""
+
+    FAN_FAULT = 25
+    """Fan fault detected in the component."""
+
+    HARDWARE_FAULT = 26
+    """Hardware fault detected in the component."""
+
+    PROTECTIVE_SHUTDOWN = 27
+    """The component performed a protective shutdown."""
+
+    GRID_OVERVOLTAGE = 30
+    """The grid voltage is over the maximum rated value."""
+
+    GRID_UNDERVOLTAGE = 31
+    """The grid voltage is under the minimum rated value."""
+
+    GRID_OVERFREQUENCY = 32
+    """The grid frequency is over the maximum rated value."""
+
+    GRID_UNDERFREQUENCY = 33
+    """The grid frequency is under the minimum rated value."""
+
+    GRID_DISCONNECTED = 34
+    """The grid is disconnected."""
+
+    GRID_VOLTAGE_IMBALANCE = 35
+    """Voltage imbalance between grid phases."""
+
+    GRID_ABNORMAL = 36
+    """The grid is in an abnormal condition not covered by other grid-specific diagnostic codes."""
+
     EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = 41
     """Electric vehicle (EV) cable was abruptly unplugged from the charging station."""
 
@@ -320,6 +380,27 @@ class ElectricalComponentDiagnosticCode(enum.Enum):
 
     RELAY_CYCLE_LIMIT_REACHED = 60
     """The relays have been cycled for the maximum number of times."""
+
+    PV_REVERSAL_POLARITY = 70
+    """Reverse polarity condition detected on the photovoltaic (PV) side."""
+
+    PV_UNDERPERFORMANCE = 71
+    """The photovoltaic (PV) system is underperforming."""
+
+    PV_FAULT = 72
+    """Fault in the photovoltaic (PV) system."""
+
+    PV_REVERSE_CURRENT = 73
+    """Reverse current condition detected on the photovoltaic (PV) side."""
+
+    PV_GROUND_FAULT = 74
+    """Ground fault detected on the photovoltaic (PV) side."""
+
+    INVERTER_DC_UNDERVOLTAGE = 80
+    """The inverter DC bus voltage is under the minimum rated value."""
+
+    INVERTER_DC_OVERVOLTAGE = 81
+    """The inverter DC bus voltage is over the maximum rated value."""
 
     @classmethod
     @deprecated(

--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -83,7 +83,8 @@ class ElectricalComponentCategory(enum.Enum):
     @deprecated(
         "frequenz.client.common.microgrid.electrical_components."
         "ElectricalComponentCategory.from_proto() is deprecated. "
-        "Use frequenz.client.common.proto.enum_from_proto instead."
+        "Use frequenz.client.common.microgrid.electrical_components.proto."
+        "v1alpha8.electrical_component_category_from_proto instead."
     )
     def from_proto(
         cls, component_category: PBElectricalComponentCategory.ValueType
@@ -106,7 +107,7 @@ class ElectricalComponentCategory(enum.Enum):
         Returns:
             Enum value corresponding to the protobuf message.
         """
-        return self.value
+        return PBElectricalComponentCategory.ValueType(self.value)
 
 
 @enum.unique
@@ -185,7 +186,8 @@ class ElectricalComponentStateCode(enum.Enum):
     @deprecated(
         "frequenz.client.common.microgrid.electrical_components."
         "ElectricalComponentStateCode.from_proto() is deprecated. "
-        "Use frequenz.client.common.proto.enum_from_proto instead."
+        "Use frequenz.client.common.microgrid.electrical_components.proto."
+        "v1alpha8.electrical_component_state_code_from_proto instead."
     )
     def from_proto(
         cls, component_state: PBElectricalComponentStateCode.ValueType
@@ -208,7 +210,7 @@ class ElectricalComponentStateCode(enum.Enum):
         Returns:
             Enum value corresponding to the protobuf message.
         """
-        return self.value
+        return PBElectricalComponentStateCode.ValueType(self.value)
 
 
 @enum.unique
@@ -336,7 +338,8 @@ class ElectricalComponentDiagnosticCode(enum.Enum):
     @deprecated(
         "frequenz.client.common.microgrid.electrical_components."
         "ElectricalComponentDiagnosticCode.from_proto() is deprecated. "
-        "Use frequenz.client.common.proto.enum_from_proto instead."
+        "Use frequenz.client.common.microgrid.electrical_components.proto."
+        "v1alpha8.electrical_component_diagnostic_code_from_proto instead."
     )
     def from_proto(
         cls, component_error_code: PBElectricalComponentDiagnosticCode.ValueType
@@ -361,4 +364,4 @@ class ElectricalComponentDiagnosticCode(enum.Enum):
         Returns:
             Enum value corresponding to the protobuf message.
         """
-        return self.value
+        return PBElectricalComponentDiagnosticCode.ValueType(self.value)

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Electrical component objects to proto conversion functions."""

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
@@ -1,0 +1,22 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of electrical component enums from/to protobuf v1alpha8."""
+
+from ._electrical_component import (
+    electrical_component_category_from_proto,
+    electrical_component_category_to_proto,
+    electrical_component_diagnostic_code_from_proto,
+    electrical_component_diagnostic_code_to_proto,
+    electrical_component_state_code_from_proto,
+    electrical_component_state_code_to_proto,
+)
+
+__all__ = [
+    "electrical_component_category_from_proto",
+    "electrical_component_category_to_proto",
+    "electrical_component_diagnostic_code_from_proto",
+    "electrical_component_diagnostic_code_to_proto",
+    "electrical_component_state_code_from_proto",
+    "electrical_component_state_code_to_proto",
+]

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -1,0 +1,108 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of electrical component enums to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from .....proto import enum_from_proto
+from ... import (
+    ElectricalComponentCategory,
+    ElectricalComponentDiagnosticCode,
+    ElectricalComponentStateCode,
+)
+
+
+def electrical_component_category_from_proto(
+    message: electrical_components_pb2.ElectricalComponentCategory.ValueType,
+) -> ElectricalComponentCategory | int:
+    """Convert a protobuf ElectricalComponentCategory enum value to an enum member.
+
+    Args:
+        message: A protobuf ElectricalComponentCategory enum value.
+
+    Returns:
+        The corresponding ElectricalComponentCategory enum member, or the raw `int`
+            if the protobuf value is not recognized.
+    """
+    return enum_from_proto(message, ElectricalComponentCategory)
+
+
+def electrical_component_category_to_proto(
+    category: ElectricalComponentCategory,
+) -> electrical_components_pb2.ElectricalComponentCategory.ValueType:
+    """Convert an ElectricalComponentCategory enum member to a protobuf enum value.
+
+    Args:
+        category: An ElectricalComponentCategory enum member.
+
+    Returns:
+        The corresponding protobuf ElectricalComponentCategory enum value.
+    """
+    return electrical_components_pb2.ElectricalComponentCategory.ValueType(
+        category.value
+    )
+
+
+def electrical_component_state_code_from_proto(
+    message: electrical_components_pb2.ElectricalComponentStateCode.ValueType,
+) -> ElectricalComponentStateCode | int:
+    """Convert a protobuf ElectricalComponentStateCode enum value to an enum member.
+
+    Args:
+        message: A protobuf ElectricalComponentStateCode enum value.
+
+    Returns:
+        The corresponding ElectricalComponentStateCode enum member, or the raw `int`
+            if the protobuf value is not recognized.
+    """
+    return enum_from_proto(message, ElectricalComponentStateCode)
+
+
+def electrical_component_state_code_to_proto(
+    state_code: ElectricalComponentStateCode,
+) -> electrical_components_pb2.ElectricalComponentStateCode.ValueType:
+    """Convert an ElectricalComponentStateCode enum member to a protobuf enum value.
+
+    Args:
+        state_code: An ElectricalComponentStateCode enum member.
+
+    Returns:
+        The corresponding protobuf ElectricalComponentStateCode enum value.
+    """
+    return electrical_components_pb2.ElectricalComponentStateCode.ValueType(
+        state_code.value
+    )
+
+
+def electrical_component_diagnostic_code_from_proto(
+    message: electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType,
+) -> ElectricalComponentDiagnosticCode | int:
+    """Convert a protobuf ElectricalComponentDiagnosticCode value to an enum member.
+
+    Args:
+        message: A protobuf ElectricalComponentDiagnosticCode enum value.
+
+    Returns:
+        The corresponding ElectricalComponentDiagnosticCode enum member, or the raw
+            `int` if the protobuf value is not recognized.
+    """
+    return enum_from_proto(message, ElectricalComponentDiagnosticCode)
+
+
+def electrical_component_diagnostic_code_to_proto(
+    diagnostic_code: ElectricalComponentDiagnosticCode,
+) -> electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType:
+    """Convert an ElectricalComponentDiagnosticCode enum member to a protobuf value.
+
+    Args:
+        diagnostic_code: An ElectricalComponentDiagnosticCode enum member.
+
+    Returns:
+        The corresponding protobuf ElectricalComponentDiagnosticCode enum value.
+    """
+    return electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType(
+        diagnostic_code.value
+    )

--- a/src/frequenz/client/common/streaming/__init__.py
+++ b/src/frequenz/client/common/streaming/__init__.py
@@ -5,21 +5,18 @@
 
 from enum import Enum
 
-# pylint: disable-next=no-name-in-module
-from frequenz.api.common.v1alpha8.streaming import event_pb2 as PBEvent
-
 
 class Event(Enum):
     """Enum representing the type of streaming event."""
 
-    UNSPECIFIED = PBEvent.EVENT_UNSPECIFIED
+    UNSPECIFIED = 0
     """Unspecified event type."""
 
-    CREATED = PBEvent.EVENT_CREATED
+    CREATED = 1
     """Event when a new resource is created."""
 
-    UPDATED = PBEvent.EVENT_UPDATED
+    UPDATED = 2
     """Event when an existing resource is updated."""
 
-    DELETED = PBEvent.EVENT_DELETED
+    DELETED = 3
     """Event when a resource is deleted."""

--- a/src/frequenz/client/common/streaming/proto/__init__.py
+++ b/src/frequenz/client/common/streaming/proto/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Streaming objects to proto conversion functions."""

--- a/src/frequenz/client/common/streaming/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/streaming/proto/v1alpha8/__init__.py
@@ -1,0 +1,11 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of Event from/to protobuf v1alpha8."""
+
+from ._event import event_from_proto, event_to_proto
+
+__all__ = [
+    "event_from_proto",
+    "event_to_proto",
+]

--- a/src/frequenz/client/common/streaming/proto/v1alpha8/_event.py
+++ b/src/frequenz/client/common/streaming/proto/v1alpha8/_event.py
@@ -1,0 +1,34 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of Event to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.streaming import event_pb2
+
+from ....proto import enum_from_proto
+from ... import Event
+
+
+def event_from_proto(message: event_pb2.Event.ValueType) -> Event | int:
+    """Convert a protobuf Event enum value to an Event enum member.
+
+    Args:
+        message: A protobuf Event enum value.
+
+    Returns:
+        The corresponding Event enum member, or the raw `int` if the protobuf value
+            is not recognized.
+    """
+    return enum_from_proto(message, Event)
+
+
+def event_to_proto(event: Event) -> event_pb2.Event.ValueType:
+    """Convert an Event enum member to a protobuf Event enum value.
+
+    Args:
+        event: An Event enum member.
+
+    Returns:
+        The corresponding protobuf Event enum value.
+    """
+    return event_pb2.Event.ValueType(event.value)

--- a/src/frequenz/client/common/test/__init__.py
+++ b/src/frequenz/client/common/test/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Test utilities."""

--- a/src/frequenz/client/common/test/enum_parity.py
+++ b/src/frequenz/client/common/test/enum_parity.py
@@ -1,0 +1,181 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Shared parity and conversion test base class for protobuf-backed enums.
+
+Every Python enum that mirrors a protobuf enum follows the same convention:
+
+* The protobuf enum value name is a fixed prefix (e.g. ``EVENT_``) followed by
+  the Python enum member name.
+* The protobuf enum value number matches the Python enum value.
+* There is a versioned ``<enum>_from_proto`` function returning the Python
+  enum member for known values and the raw ``int`` for unknown values.
+* There is a versioned ``<enum>_to_proto`` function returning the numeric
+  protobuf value.
+
+[`EnumParityTest`][frequenz.client.common.test.enum_parity.EnumParityTest] is
+a parametrized `pytest` base class covering all those invariants. New enum
+wrappers add a one-line subclass that pins the protobuf-specific attributes
+instead of copy-pasting the same scaffold.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import Enum
+from typing import Any, ClassVar
+
+import pytest
+
+
+class EnumParityTest:
+    """Base test class checking protobuf/Python enum parity.
+
+    Subclasses must set `python_enum`, `proto_enum`, `name_prefix`,
+    `from_proto` and `to_proto`. The subclass name must start with ``Test`` so
+    `pytest` picks it up.
+
+    For each subclass, the inherited tests verify that:
+
+    * every protobuf enum name maps to a Python enum member with the same value
+      (tolerating new protobuf values not yet mirrored in Python);
+    * every Python enum member maps to a protobuf enum name and value;
+    * `from_proto` returns the matching member for known values and the raw
+      `int` for unknown values;
+    * `to_proto` returns the numeric protobuf value.
+
+    Subclasses are free to add further `test_*` methods.
+
+    Example:
+        ```python
+        from frequenz.api.common.v1alpha8.streaming import event_pb2
+
+        from frequenz.client.common.streaming import Event
+        from frequenz.client.common.streaming.proto.v1alpha8 import (
+            event_from_proto,
+            event_to_proto,
+        )
+
+        from frequenz.client.common.test.enum_parity import EnumParityTest
+
+
+        class TestEventParity(EnumParityTest):
+            python_enum = Event
+            proto_enum = event_pb2.Event
+            name_prefix = "EVENT_"
+            from_proto = staticmethod(event_from_proto)
+            to_proto = staticmethod(event_to_proto)
+        ```
+
+    Attributes:
+        python_enum: The Python enum subclass mirroring the protobuf enum.
+        proto_enum: The generated protobuf enum wrapper (e.g.
+            ``event_pb2.Event``). Must expose ``DESCRIPTOR.values``,
+            ``Value(name)``, ``Name(value)`` and ``ValueType``.
+        name_prefix: Prefix used for protobuf enum value names (e.g.
+            ``"EVENT_"``).
+        from_proto: Versioned converter from a protobuf enum value to the
+            Python enum. Returns the Python enum member for known values, or
+            the raw `int` for unknown values. Bind with ``staticmethod(...)``
+            in the subclass.
+        to_proto: Versioned converter from a Python enum member to a protobuf
+            enum value. Bind with ``staticmethod(...)`` in the subclass.
+    """
+
+    python_enum: ClassVar[type[Enum]]
+    proto_enum: ClassVar[Any]
+    name_prefix: ClassVar[str]
+    from_proto: ClassVar[Callable[..., Any]]
+    to_proto: ClassVar[Callable[..., int]]
+
+    def pytest_generate_tests(self, metafunc: pytest.Metafunc) -> None:
+        """Parametrize ``pb_name`` and ``member`` from the configured enums.
+
+        Args:
+            metafunc: The `pytest` metafunc object for the test being collected.
+        """
+        if "pb_name" in metafunc.fixturenames:
+            pb_names = [m.name for m in self.proto_enum.DESCRIPTOR.values]
+            metafunc.parametrize("pb_name", pb_names)
+        if "member" in metafunc.fixturenames:
+            members = list(self.python_enum)
+            metafunc.parametrize("member", members, ids=lambda m: m.name)
+
+    def test_proto_enum_matches_enum_name(self, pb_name: str) -> None:
+        """Test that all known protobuf enum names match a Python member.
+
+        Args:
+            pb_name: The protobuf enum value name to check.
+        """
+        pb_value = self.proto_enum.Value(pb_name)
+        try:
+            member = self.python_enum[pb_name.removeprefix(self.name_prefix)]
+        except KeyError:
+            # It is OK to have new protobuf enum values not yet in the Python
+            # enum.
+            return
+        assert member.value == pb_value
+
+    def test_proto_enum_matches_enum_value(self, pb_name: str) -> None:
+        """Test that all known protobuf enum values match a Python member.
+
+        Args:
+            pb_name: The protobuf enum value name to check.
+        """
+        pb_value = self.proto_enum.Value(pb_name)
+        try:
+            member = self.python_enum(pb_value)
+        except ValueError:
+            # It is OK to have new protobuf enum values not yet in the Python
+            # enum.
+            return
+        assert member.value == pb_value
+
+    def test_enum_matches_proto_enum_name(self, member: Enum) -> None:
+        """Test that all Python enum members have a matching protobuf name.
+
+        Args:
+            member: The Python enum member to check.
+        """
+        pb_value = self.proto_enum.ValueType(member.value)
+        pb_name = self.proto_enum.Name(pb_value)
+        assert pb_name == f"{self.name_prefix}{member.name}"
+
+    def test_enum_matches_proto_enum_value(self, member: Enum) -> None:
+        """Test that all Python enum members have a matching protobuf value.
+
+        Args:
+            member: The Python enum member to check.
+        """
+        pb_value = self.proto_enum.Value(f"{self.name_prefix}{member.name}")
+        assert member.value == pb_value
+
+    def test_from_proto(self, pb_name: str) -> None:
+        """Test conversion from protobuf returns a matching member or int.
+
+        Args:
+            pb_name: The protobuf enum value name to convert.
+        """
+        pb_value = self.proto_enum.Value(pb_name)
+        result = self.from_proto(pb_value)
+        if pb_value in [m.value for m in self.python_enum]:
+            assert result is self.python_enum(pb_value)
+        else:
+            assert result == pb_value
+
+    def test_from_proto_unknown(self) -> None:
+        """Test conversion from protobuf for unknown values returns the int."""
+        max_value = max(m.value for m in self.python_enum)
+        unknown_pb_value = self.proto_enum.ValueType(max_value + 1)
+        result = self.from_proto(unknown_pb_value)
+        assert isinstance(result, int)
+        assert result == unknown_pb_value
+
+    def test_to_proto(self, member: Enum) -> None:
+        """Test conversion to protobuf returns a matching protobuf value.
+
+        Args:
+            member: The Python enum member to convert.
+        """
+        pb_value = self.to_proto(member)
+        assert pb_value == member.value

--- a/tests/metrics/proto/test_sample_metric_connection.py
+++ b/tests/metrics/proto/test_sample_metric_connection.py
@@ -9,12 +9,17 @@ from frequenz.client.common.metrics import MetricConnectionCategory
 from frequenz.client.common.metrics.proto import (
     metric_connection_from_proto_with_issues,
 )
+from frequenz.client.common.metrics.proto.v1alpha8 import (
+    metric_connection_category_to_proto,
+)
 
 
 def test_with_unspecified_category() -> None:
     """Test conversion with UNSPECIFIED category reports major issue."""
     proto = metrics_pb2.MetricConnection(
-        category=metrics_pb2.METRIC_CONNECTION_CATEGORY_UNSPECIFIED,
+        category=metric_connection_category_to_proto(
+            MetricConnectionCategory.UNSPECIFIED
+        ),
         name="some_connection",
     )
 
@@ -54,7 +59,7 @@ def test_with_unrecognized_category() -> None:
 def test_with_valid_category() -> None:
     """Test conversion with valid category does not report issues."""
     proto = metrics_pb2.MetricConnection(
-        category=metrics_pb2.METRIC_CONNECTION_CATEGORY_BATTERY,
+        category=metric_connection_category_to_proto(MetricConnectionCategory.BATTERY),
         name="dc_battery_0",
     )
 
@@ -74,7 +79,7 @@ def test_with_valid_category() -> None:
 def test_with_empty_name() -> None:
     """Test conversion with empty name becomes None."""
     proto = metrics_pb2.MetricConnection(
-        category=metrics_pb2.METRIC_CONNECTION_CATEGORY_PV,
+        category=metric_connection_category_to_proto(MetricConnectionCategory.PV),
         name="",
     )
 

--- a/tests/metrics/proto/test_sample_metric_sample.py
+++ b/tests/metrics/proto/test_sample_metric_sample.py
@@ -20,7 +20,10 @@ from frequenz.client.common.metrics import (
     MetricSample,
 )
 from frequenz.client.common.metrics.proto import metric_sample_from_proto_with_issues
-from frequenz.client.common.metrics.proto.v1alpha8 import metric_to_proto
+from frequenz.client.common.metrics.proto.v1alpha8 import (
+    metric_connection_category_to_proto,
+    metric_to_proto,
+)
 
 DATETIME: Final[datetime] = datetime(2023, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
 TIMESTAMP: Final[Timestamp] = Timestamp(seconds=int(DATETIME.timestamp()))
@@ -166,7 +169,9 @@ class _TestCase:
                     simple_metric=metrics_pb2.SimpleMetricValue(value=5.0)
                 ),
                 connection=metrics_pb2.MetricConnection(
-                    category=metrics_pb2.METRIC_CONNECTION_CATEGORY_BATTERY,
+                    category=metric_connection_category_to_proto(
+                        MetricConnectionCategory.BATTERY
+                    ),
                     name="dc_battery_0",
                 ),
             ),

--- a/tests/metrics/proto/v1alpha8/test_metric.py
+++ b/tests/metrics/proto/v1alpha8/test_metric.py
@@ -1,13 +1,8 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Tests for Metric to/from protobuf v1alpha8 conversion.
+"""Tests for Metric to/from protobuf v1alpha8 conversion."""
 
-These tests ensure that, for this version, all enum members are correctly matched by
-name and value between the Python `Metric` enum and the protobuf `Metric` enum.
-"""
-
-import pytest
 from frequenz.api.common.v1alpha8.metrics import metrics_pb2
 
 from frequenz.client.common.metrics import Metric
@@ -15,79 +10,14 @@ from frequenz.client.common.metrics.proto.v1alpha8 import (
     metric_from_proto,
     metric_to_proto,
 )
-
-PB_NAMES: list[str] = [m.name for m in metrics_pb2.Metric.DESCRIPTOR.values]
-
-UNKNOWN_PB_VALUE = metrics_pb2.Metric.ValueType(max(m.value for m in Metric) + 1)
+from frequenz.client.common.test.enum_parity import EnumParityTest
 
 
-def test_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf enum values are not implicitly convertible to Metric enum members."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    metric = list(Metric)[0]
-    _: metrics_pb2.Metric.ValueType = metric.value  # type: ignore[assignment]
-    metrics_pb2.Metric.Name(metric.value)  # type: ignore[arg-type]
+class TestMetricParity(EnumParityTest):
+    """Parity tests for the `Metric` enum."""
 
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf enum names have a matching Metric enum member."""
-    pb_value = metrics_pb2.Metric.Value(pb_name)
-    try:
-        metric = Metric[pb_name.removeprefix("METRIC_")]
-        assert metric.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in Metric.
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf enum values have a matching Metric enum member."""
-    pb_value = metrics_pb2.Metric.Value(pb_name)
-    try:
-        metric = Metric(pb_value)
-        assert metric.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in Metric.
-
-
-@pytest.mark.parametrize("metric", list(Metric), ids=lambda m: m.name)
-def test_enum_matches_proto_enum_name(metric: Metric) -> None:
-    """Test that all Metric enum members have a matching protobuf enum name."""
-    pb_value = metrics_pb2.Metric.ValueType(metric.value)
-    pb_name = metrics_pb2.Metric.Name(pb_value)
-    assert pb_name == f"METRIC_{metric.name}"
-
-
-@pytest.mark.parametrize("metric", list(Metric), ids=lambda m: m.name)
-def test_enum_matches_proto_enum_value(metric: Metric) -> None:
-    """Test that all Metric enum members have a matching protobuf enum value."""
-    pb_value = metrics_pb2.Metric.Value(f"METRIC_{metric.name}")
-    assert metric.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_from_proto(pb_name: str) -> None:
-    """Test conversion from protobuf returns a matching member or the int for unknown values."""
-    pb_value = metrics_pb2.Metric.Value(pb_name)
-    metric = metric_from_proto(pb_value)
-    if pb_value in [m.value for m in Metric]:
-        assert metric is Metric(pb_value)
-    else:
-        assert metric == pb_value
-
-
-def test_from_proto_unknown() -> None:
-    """Test conversion from protobuf for yet unknown values return the int."""
-    metric = metric_from_proto(UNKNOWN_PB_VALUE)
-    assert isinstance(metric, int)
-    assert metric == UNKNOWN_PB_VALUE
-
-
-@pytest.mark.parametrize("metric", list(Metric), ids=lambda m: m.name)
-def test_to_proto(metric: Metric) -> None:
-    """Test conversion to protobuf return a matching protobuf value."""
-    pb_value = metric_to_proto(metric)
-    assert pb_value == metric.value
+    python_enum = Metric
+    proto_enum = metrics_pb2.Metric
+    name_prefix = "METRIC_"
+    from_proto = staticmethod(metric_from_proto)
+    to_proto = staticmethod(metric_to_proto)

--- a/tests/metrics/proto/v1alpha8/test_metric_connection_category.py
+++ b/tests/metrics/proto/v1alpha8/test_metric_connection_category.py
@@ -1,0 +1,113 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for MetricConnectionCategory to/from protobuf v1alpha8 conversion.
+
+These tests ensure that, for this version, all enum members are correctly matched by
+name and value between the Python `MetricConnectionCategory` enum and the protobuf
+`MetricConnectionCategory` enum.
+"""
+
+from typing import TypeAlias
+
+import pytest
+from frequenz.api.common.v1alpha8.metrics import metrics_pb2
+
+from frequenz.client.common.metrics import MetricConnectionCategory
+from frequenz.client.common.metrics.proto.v1alpha8 import (
+    metric_connection_category_from_proto,
+    metric_connection_category_to_proto,
+)
+
+PB_NAMES: list[str] = [
+    m.name for m in metrics_pb2.MetricConnectionCategory.DESCRIPTOR.values
+]
+MetricConnectionCategoryValue: TypeAlias = (
+    metrics_pb2.MetricConnectionCategory.ValueType
+)
+
+UNKNOWN_PB_VALUE = metrics_pb2.MetricConnectionCategory.ValueType(
+    max(m.value for m in MetricConnectionCategory) + 1
+)
+
+
+def test_no_implicit_to_proto_conversion() -> None:
+    """Test that protobuf enum values are not implicitly convertible."""
+    # mypy should complain about this assignment, so we ignore the type check here.
+    # If mypy doesn't find an issue with this conversion, it should complain about
+    # the ignore comment having no effect.
+    category = list(MetricConnectionCategory)[0]
+    _: MetricConnectionCategoryValue = category.value  # type: ignore[assignment]
+    metrics_pb2.MetricConnectionCategory.Name(category.value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_proto_enum_matches_enum_name(pb_name: str) -> None:
+    """Test that all known protobuf enum names have a matching enum member."""
+    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
+    try:
+        category = MetricConnectionCategory[
+            pb_name.removeprefix("METRIC_CONNECTION_CATEGORY_")
+        ]
+        assert category.value == pb_value
+    except KeyError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_proto_enum_matches_enum_value(pb_name: str) -> None:
+    """Test that all known protobuf enum values have a matching enum member."""
+    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
+    try:
+        category = MetricConnectionCategory(pb_value)
+        assert category.value == pb_value
+    except ValueError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize(
+    "category", list(MetricConnectionCategory), ids=lambda m: m.name
+)
+def test_enum_matches_proto_enum_name(category: MetricConnectionCategory) -> None:
+    """Test that all enum members have a matching protobuf enum name."""
+    pb_value = metrics_pb2.MetricConnectionCategory.ValueType(category.value)
+    pb_name = metrics_pb2.MetricConnectionCategory.Name(pb_value)
+    assert pb_name == f"METRIC_CONNECTION_CATEGORY_{category.name}"
+
+
+@pytest.mark.parametrize(
+    "category", list(MetricConnectionCategory), ids=lambda m: m.name
+)
+def test_enum_matches_proto_enum_value(category: MetricConnectionCategory) -> None:
+    """Test that all enum members have a matching protobuf enum value."""
+    pb_value = metrics_pb2.MetricConnectionCategory.Value(
+        f"METRIC_CONNECTION_CATEGORY_{category.name}"
+    )
+    assert category.value == pb_value
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_from_proto(pb_name: str) -> None:
+    """Test conversion from protobuf returns a matching member or int."""
+    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
+    category = metric_connection_category_from_proto(pb_value)
+    if pb_value in [m.value for m in MetricConnectionCategory]:
+        assert category is MetricConnectionCategory(pb_value)
+    else:
+        assert category == pb_value
+
+
+def test_from_proto_unknown() -> None:
+    """Test conversion from protobuf for yet unknown values return the int."""
+    category = metric_connection_category_from_proto(UNKNOWN_PB_VALUE)
+    assert isinstance(category, int)
+    assert category == UNKNOWN_PB_VALUE
+
+
+@pytest.mark.parametrize(
+    "category", list(MetricConnectionCategory), ids=lambda m: m.name
+)
+def test_to_proto(category: MetricConnectionCategory) -> None:
+    """Test conversion to protobuf return a matching protobuf value."""
+    pb_value = metric_connection_category_to_proto(category)
+    assert pb_value == category.value

--- a/tests/metrics/proto/v1alpha8/test_metric_connection_category.py
+++ b/tests/metrics/proto/v1alpha8/test_metric_connection_category.py
@@ -1,16 +1,8 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Tests for MetricConnectionCategory to/from protobuf v1alpha8 conversion.
+"""Tests for MetricConnectionCategory to/from protobuf v1alpha8 conversion."""
 
-These tests ensure that, for this version, all enum members are correctly matched by
-name and value between the Python `MetricConnectionCategory` enum and the protobuf
-`MetricConnectionCategory` enum.
-"""
-
-from typing import TypeAlias
-
-import pytest
 from frequenz.api.common.v1alpha8.metrics import metrics_pb2
 
 from frequenz.client.common.metrics import MetricConnectionCategory
@@ -18,96 +10,14 @@ from frequenz.client.common.metrics.proto.v1alpha8 import (
     metric_connection_category_from_proto,
     metric_connection_category_to_proto,
 )
-
-PB_NAMES: list[str] = [
-    m.name for m in metrics_pb2.MetricConnectionCategory.DESCRIPTOR.values
-]
-MetricConnectionCategoryValue: TypeAlias = (
-    metrics_pb2.MetricConnectionCategory.ValueType
-)
-
-UNKNOWN_PB_VALUE = metrics_pb2.MetricConnectionCategory.ValueType(
-    max(m.value for m in MetricConnectionCategory) + 1
-)
+from frequenz.client.common.test.enum_parity import EnumParityTest
 
 
-def test_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf enum values are not implicitly convertible."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    category = list(MetricConnectionCategory)[0]
-    _: MetricConnectionCategoryValue = category.value  # type: ignore[assignment]
-    metrics_pb2.MetricConnectionCategory.Name(category.value)  # type: ignore[arg-type]
+class TestMetricConnectionCategoryParity(EnumParityTest):
+    """Parity tests for the `MetricConnectionCategory` enum."""
 
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf enum names have a matching enum member."""
-    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
-    try:
-        category = MetricConnectionCategory[
-            pb_name.removeprefix("METRIC_CONNECTION_CATEGORY_")
-        ]
-        assert category.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf enum values have a matching enum member."""
-    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
-    try:
-        category = MetricConnectionCategory(pb_value)
-        assert category.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize(
-    "category", list(MetricConnectionCategory), ids=lambda m: m.name
-)
-def test_enum_matches_proto_enum_name(category: MetricConnectionCategory) -> None:
-    """Test that all enum members have a matching protobuf enum name."""
-    pb_value = metrics_pb2.MetricConnectionCategory.ValueType(category.value)
-    pb_name = metrics_pb2.MetricConnectionCategory.Name(pb_value)
-    assert pb_name == f"METRIC_CONNECTION_CATEGORY_{category.name}"
-
-
-@pytest.mark.parametrize(
-    "category", list(MetricConnectionCategory), ids=lambda m: m.name
-)
-def test_enum_matches_proto_enum_value(category: MetricConnectionCategory) -> None:
-    """Test that all enum members have a matching protobuf enum value."""
-    pb_value = metrics_pb2.MetricConnectionCategory.Value(
-        f"METRIC_CONNECTION_CATEGORY_{category.name}"
-    )
-    assert category.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_from_proto(pb_name: str) -> None:
-    """Test conversion from protobuf returns a matching member or int."""
-    pb_value = metrics_pb2.MetricConnectionCategory.Value(pb_name)
-    category = metric_connection_category_from_proto(pb_value)
-    if pb_value in [m.value for m in MetricConnectionCategory]:
-        assert category is MetricConnectionCategory(pb_value)
-    else:
-        assert category == pb_value
-
-
-def test_from_proto_unknown() -> None:
-    """Test conversion from protobuf for yet unknown values return the int."""
-    category = metric_connection_category_from_proto(UNKNOWN_PB_VALUE)
-    assert isinstance(category, int)
-    assert category == UNKNOWN_PB_VALUE
-
-
-@pytest.mark.parametrize(
-    "category", list(MetricConnectionCategory), ids=lambda m: m.name
-)
-def test_to_proto(category: MetricConnectionCategory) -> None:
-    """Test conversion to protobuf return a matching protobuf value."""
-    pb_value = metric_connection_category_to_proto(category)
-    assert pb_value == category.value
+    python_enum = MetricConnectionCategory
+    proto_enum = metrics_pb2.MetricConnectionCategory
+    name_prefix = "METRIC_CONNECTION_CATEGORY_"
+    from_proto = staticmethod(metric_connection_category_from_proto)
+    to_proto = staticmethod(metric_connection_category_to_proto)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component.py
@@ -1,0 +1,348 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for electrical component enum to/from protobuf v1alpha8 conversion.
+
+These tests ensure that, for this version, all enum members are correctly matched by
+name and value between the Python electrical component enums and the corresponding
+protobuf enums.
+"""
+
+from typing import TypeAlias
+
+import pytest
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentDiagnosticCode,
+    ElectricalComponentStateCode,
+)
+from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
+    electrical_component_category_from_proto,
+    electrical_component_category_to_proto,
+    electrical_component_diagnostic_code_from_proto,
+    electrical_component_diagnostic_code_to_proto,
+    electrical_component_state_code_from_proto,
+    electrical_component_state_code_to_proto,
+)
+
+CATEGORY_PB_NAMES: list[str] = [
+    m.name
+    for m in electrical_components_pb2.ElectricalComponentCategory.DESCRIPTOR.values
+]
+CategoryValue: TypeAlias = (
+    electrical_components_pb2.ElectricalComponentCategory.ValueType
+)
+STATE_CODE_PB_NAMES: list[str] = [
+    m.name
+    for m in electrical_components_pb2.ElectricalComponentStateCode.DESCRIPTOR.values
+]
+StateCodeValue: TypeAlias = (
+    electrical_components_pb2.ElectricalComponentStateCode.ValueType
+)
+DIAGNOSTIC_CODE_PB_NAMES: list[str] = [
+    m.name
+    for m in electrical_components_pb2.ElectricalComponentDiagnosticCode.DESCRIPTOR.values
+]
+DiagnosticCodeValue: TypeAlias = (
+    electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType
+)
+
+UNKNOWN_CATEGORY_PB_VALUE = (
+    electrical_components_pb2.ElectricalComponentCategory.ValueType(
+        max(m.value for m in ElectricalComponentCategory) + 1
+    )
+)
+UNKNOWN_STATE_CODE_PB_VALUE = (
+    electrical_components_pb2.ElectricalComponentStateCode.ValueType(
+        max(m.value for m in ElectricalComponentStateCode) + 1
+    )
+)
+UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE = (
+    electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType(
+        max(m.value for m in ElectricalComponentDiagnosticCode) + 1
+    )
+)
+
+
+def test_category_no_implicit_to_proto_conversion() -> None:
+    """Test that protobuf category values are not implicitly convertible."""
+    # mypy should complain about this assignment, so we ignore the type check here.
+    # If mypy doesn't find an issue with this conversion, it should complain about
+    # the ignore comment having no effect.
+    category = list(ElectricalComponentCategory)[0]
+    _: CategoryValue = category.value  # type: ignore[assignment]
+    electrical_components_pb2.ElectricalComponentCategory.Name(
+        category.value  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
+def test_category_proto_enum_matches_enum_name(pb_name: str) -> None:
+    """Test that all known protobuf category names have a matching enum member."""
+    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
+    try:
+        category = ElectricalComponentCategory[
+            pb_name.removeprefix("ELECTRICAL_COMPONENT_CATEGORY_")
+        ]
+        assert category.value == pb_value
+    except KeyError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
+def test_category_proto_enum_matches_enum_value(pb_name: str) -> None:
+    """Test that all known protobuf category values have a matching enum member."""
+    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
+    try:
+        category = ElectricalComponentCategory(pb_value)
+        assert category.value == pb_value
+    except ValueError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize(
+    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
+)
+def test_category_enum_matches_proto_enum_name(
+    category: ElectricalComponentCategory,
+) -> None:
+    """Test that all category enum members have a matching protobuf enum name."""
+    pb_value = electrical_components_pb2.ElectricalComponentCategory.ValueType(
+        category.value
+    )
+    pb_name = electrical_components_pb2.ElectricalComponentCategory.Name(pb_value)
+    assert pb_name == f"ELECTRICAL_COMPONENT_CATEGORY_{category.name}"
+
+
+@pytest.mark.parametrize(
+    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
+)
+def test_category_enum_matches_proto_enum_value(
+    category: ElectricalComponentCategory,
+) -> None:
+    """Test that all category enum members have a matching protobuf enum value."""
+    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(
+        f"ELECTRICAL_COMPONENT_CATEGORY_{category.name}"
+    )
+    assert category.value == pb_value
+
+
+@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
+def test_category_from_proto(pb_name: str) -> None:
+    """Test category conversion from protobuf returns a matching member or int."""
+    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
+    category = electrical_component_category_from_proto(pb_value)
+    if pb_value in [m.value for m in ElectricalComponentCategory]:
+        assert category is ElectricalComponentCategory(pb_value)
+    else:
+        assert category == pb_value
+
+
+def test_category_from_proto_unknown() -> None:
+    """Test category conversion from protobuf for unknown values returns the int."""
+    category = electrical_component_category_from_proto(UNKNOWN_CATEGORY_PB_VALUE)
+    assert isinstance(category, int)
+    assert category == UNKNOWN_CATEGORY_PB_VALUE
+
+
+@pytest.mark.parametrize(
+    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
+)
+def test_category_to_proto(category: ElectricalComponentCategory) -> None:
+    """Test category conversion to protobuf returns a matching protobuf value."""
+    pb_value = electrical_component_category_to_proto(category)
+    assert pb_value == category.value
+
+
+def test_state_code_no_implicit_to_proto_conversion() -> None:
+    """Test that protobuf state code values are not implicitly convertible."""
+    # mypy should complain about this assignment, so we ignore the type check here.
+    # If mypy doesn't find an issue with this conversion, it should complain about
+    # the ignore comment having no effect.
+    state_code = list(ElectricalComponentStateCode)[0]
+    _: StateCodeValue = state_code.value  # type: ignore[assignment]
+    electrical_components_pb2.ElectricalComponentStateCode.Name(
+        state_code.value  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
+def test_state_code_proto_enum_matches_enum_name(pb_name: str) -> None:
+    """Test that all known protobuf state code names have a matching enum member."""
+    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
+    try:
+        state_code = ElectricalComponentStateCode[
+            pb_name.removeprefix("ELECTRICAL_COMPONENT_STATE_CODE_")
+        ]
+        assert state_code.value == pb_value
+    except KeyError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
+def test_state_code_proto_enum_matches_enum_value(pb_name: str) -> None:
+    """Test that all known protobuf state code values have a matching enum member."""
+    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
+    try:
+        state_code = ElectricalComponentStateCode(pb_value)
+        assert state_code.value == pb_value
+    except ValueError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize(
+    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
+)
+def test_state_code_enum_matches_proto_enum_name(
+    state_code: ElectricalComponentStateCode,
+) -> None:
+    """Test that all state code enum members have a matching protobuf enum name."""
+    pb_value = electrical_components_pb2.ElectricalComponentStateCode.ValueType(
+        state_code.value
+    )
+    pb_name = electrical_components_pb2.ElectricalComponentStateCode.Name(pb_value)
+    assert pb_name == f"ELECTRICAL_COMPONENT_STATE_CODE_{state_code.name}"
+
+
+@pytest.mark.parametrize(
+    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
+)
+def test_state_code_enum_matches_proto_enum_value(
+    state_code: ElectricalComponentStateCode,
+) -> None:
+    """Test that all state code enum members have a matching protobuf enum value."""
+    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(
+        f"ELECTRICAL_COMPONENT_STATE_CODE_{state_code.name}"
+    )
+    assert state_code.value == pb_value
+
+
+@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
+def test_state_code_from_proto(pb_name: str) -> None:
+    """Test state code conversion from protobuf returns a matching member or int."""
+    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
+    state_code = electrical_component_state_code_from_proto(pb_value)
+    if pb_value in [m.value for m in ElectricalComponentStateCode]:
+        assert state_code is ElectricalComponentStateCode(pb_value)
+    else:
+        assert state_code == pb_value
+
+
+def test_state_code_from_proto_unknown() -> None:
+    """Test state code conversion from protobuf for unknown values returns the int."""
+    state_code = electrical_component_state_code_from_proto(UNKNOWN_STATE_CODE_PB_VALUE)
+    assert isinstance(state_code, int)
+    assert state_code == UNKNOWN_STATE_CODE_PB_VALUE
+
+
+@pytest.mark.parametrize(
+    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
+)
+def test_state_code_to_proto(state_code: ElectricalComponentStateCode) -> None:
+    """Test state code conversion to protobuf returns a matching protobuf value."""
+    pb_value = electrical_component_state_code_to_proto(state_code)
+    assert pb_value == state_code.value
+
+
+def test_diagnostic_code_no_implicit_to_proto_conversion() -> None:
+    """Test that protobuf diagnostic code values are not implicitly convertible."""
+    # mypy should complain about this assignment, so we ignore the type check here.
+    # If mypy doesn't find an issue with this conversion, it should complain about
+    # the ignore comment having no effect.
+    diagnostic_code = list(ElectricalComponentDiagnosticCode)[0]
+    _: DiagnosticCodeValue = diagnostic_code.value  # type: ignore[assignment]
+    electrical_components_pb2.ElectricalComponentDiagnosticCode.Name(
+        diagnostic_code.value  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
+def test_diagnostic_code_proto_enum_matches_enum_name(pb_name: str) -> None:
+    """Test that all known protobuf diagnostic code names have a matching member."""
+    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
+        pb_name
+    )
+    try:
+        diagnostic_code = ElectricalComponentDiagnosticCode[
+            pb_name.removeprefix("ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_")
+        ]
+        assert diagnostic_code.value == pb_value
+    except KeyError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
+def test_diagnostic_code_proto_enum_matches_enum_value(pb_name: str) -> None:
+    """Test that all known protobuf diagnostic code values have a matching member."""
+    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
+        pb_name
+    )
+    try:
+        diagnostic_code = ElectricalComponentDiagnosticCode(pb_value)
+        assert diagnostic_code.value == pb_value
+    except ValueError:
+        pass  # It is OK to have new protobuf enum values not yet in the enum.
+
+
+@pytest.mark.parametrize(
+    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
+)
+def test_diagnostic_code_enum_matches_proto_enum_name(
+    diagnostic_code: ElectricalComponentDiagnosticCode,
+) -> None:
+    """Test that all diagnostic code enum members have a matching protobuf name."""
+    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType(
+        diagnostic_code.value
+    )
+    pb_name = electrical_components_pb2.ElectricalComponentDiagnosticCode.Name(pb_value)
+    assert pb_name == f"ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_{diagnostic_code.name}"
+
+
+@pytest.mark.parametrize(
+    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
+)
+def test_diagnostic_code_enum_matches_proto_enum_value(
+    diagnostic_code: ElectricalComponentDiagnosticCode,
+) -> None:
+    """Test that all diagnostic code enum members have a matching protobuf value."""
+    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
+        f"ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_{diagnostic_code.name}"
+    )
+    assert diagnostic_code.value == pb_value
+
+
+@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
+def test_diagnostic_code_from_proto(pb_name: str) -> None:
+    """Test diagnostic code conversion from protobuf returns a matching member or int."""
+    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
+        pb_name
+    )
+    diagnostic_code = electrical_component_diagnostic_code_from_proto(pb_value)
+    if pb_value in [m.value for m in ElectricalComponentDiagnosticCode]:
+        assert diagnostic_code is ElectricalComponentDiagnosticCode(pb_value)
+    else:
+        assert diagnostic_code == pb_value
+
+
+def test_diagnostic_code_from_proto_unknown() -> None:
+    """Test diagnostic code conversion from protobuf for unknown values returns the int."""
+    diagnostic_code = electrical_component_diagnostic_code_from_proto(
+        UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE
+    )
+    assert isinstance(diagnostic_code, int)
+    assert diagnostic_code == UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE
+
+
+@pytest.mark.parametrize(
+    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
+)
+def test_diagnostic_code_to_proto(
+    diagnostic_code: ElectricalComponentDiagnosticCode,
+) -> None:
+    """Test diagnostic code conversion to protobuf returns a matching value."""
+    pb_value = electrical_component_diagnostic_code_to_proto(diagnostic_code)
+    assert pb_value == diagnostic_code.value

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component.py
@@ -1,16 +1,8 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Tests for electrical component enum to/from protobuf v1alpha8 conversion.
+"""Tests for electrical component enum to/from protobuf v1alpha8 conversion."""
 
-These tests ensure that, for this version, all enum members are correctly matched by
-name and value between the Python electrical component enums and the corresponding
-protobuf enums.
-"""
-
-from typing import TypeAlias
-
-import pytest
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
 )
@@ -28,321 +20,34 @@ from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 impor
     electrical_component_state_code_from_proto,
     electrical_component_state_code_to_proto,
 )
-
-CATEGORY_PB_NAMES: list[str] = [
-    m.name
-    for m in electrical_components_pb2.ElectricalComponentCategory.DESCRIPTOR.values
-]
-CategoryValue: TypeAlias = (
-    electrical_components_pb2.ElectricalComponentCategory.ValueType
-)
-STATE_CODE_PB_NAMES: list[str] = [
-    m.name
-    for m in electrical_components_pb2.ElectricalComponentStateCode.DESCRIPTOR.values
-]
-StateCodeValue: TypeAlias = (
-    electrical_components_pb2.ElectricalComponentStateCode.ValueType
-)
-DIAGNOSTIC_CODE_PB_NAMES: list[str] = [
-    m.name
-    for m in electrical_components_pb2.ElectricalComponentDiagnosticCode.DESCRIPTOR.values
-]
-DiagnosticCodeValue: TypeAlias = (
-    electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType
-)
-
-UNKNOWN_CATEGORY_PB_VALUE = (
-    electrical_components_pb2.ElectricalComponentCategory.ValueType(
-        max(m.value for m in ElectricalComponentCategory) + 1
-    )
-)
-UNKNOWN_STATE_CODE_PB_VALUE = (
-    electrical_components_pb2.ElectricalComponentStateCode.ValueType(
-        max(m.value for m in ElectricalComponentStateCode) + 1
-    )
-)
-UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE = (
-    electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType(
-        max(m.value for m in ElectricalComponentDiagnosticCode) + 1
-    )
-)
+from frequenz.client.common.test.enum_parity import EnumParityTest
 
 
-def test_category_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf category values are not implicitly convertible."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    category = list(ElectricalComponentCategory)[0]
-    _: CategoryValue = category.value  # type: ignore[assignment]
-    electrical_components_pb2.ElectricalComponentCategory.Name(
-        category.value  # type: ignore[arg-type]
-    )
+class TestElectricalComponentCategoryParity(EnumParityTest):
+    """Parity tests for the `ElectricalComponentCategory` enum."""
+
+    python_enum = ElectricalComponentCategory
+    proto_enum = electrical_components_pb2.ElectricalComponentCategory
+    name_prefix = "ELECTRICAL_COMPONENT_CATEGORY_"
+    from_proto = staticmethod(electrical_component_category_from_proto)
+    to_proto = staticmethod(electrical_component_category_to_proto)
 
 
-@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
-def test_category_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf category names have a matching enum member."""
-    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
-    try:
-        category = ElectricalComponentCategory[
-            pb_name.removeprefix("ELECTRICAL_COMPONENT_CATEGORY_")
-        ]
-        assert category.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
+class TestElectricalComponentStateCodeParity(EnumParityTest):
+    """Parity tests for the `ElectricalComponentStateCode` enum."""
+
+    python_enum = ElectricalComponentStateCode
+    proto_enum = electrical_components_pb2.ElectricalComponentStateCode
+    name_prefix = "ELECTRICAL_COMPONENT_STATE_CODE_"
+    from_proto = staticmethod(electrical_component_state_code_from_proto)
+    to_proto = staticmethod(electrical_component_state_code_to_proto)
 
 
-@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
-def test_category_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf category values have a matching enum member."""
-    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
-    try:
-        category = ElectricalComponentCategory(pb_value)
-        assert category.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
+class TestElectricalComponentDiagnosticCodeParity(EnumParityTest):
+    """Parity tests for the `ElectricalComponentDiagnosticCode` enum."""
 
-
-@pytest.mark.parametrize(
-    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
-)
-def test_category_enum_matches_proto_enum_name(
-    category: ElectricalComponentCategory,
-) -> None:
-    """Test that all category enum members have a matching protobuf enum name."""
-    pb_value = electrical_components_pb2.ElectricalComponentCategory.ValueType(
-        category.value
-    )
-    pb_name = electrical_components_pb2.ElectricalComponentCategory.Name(pb_value)
-    assert pb_name == f"ELECTRICAL_COMPONENT_CATEGORY_{category.name}"
-
-
-@pytest.mark.parametrize(
-    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
-)
-def test_category_enum_matches_proto_enum_value(
-    category: ElectricalComponentCategory,
-) -> None:
-    """Test that all category enum members have a matching protobuf enum value."""
-    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(
-        f"ELECTRICAL_COMPONENT_CATEGORY_{category.name}"
-    )
-    assert category.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", CATEGORY_PB_NAMES)
-def test_category_from_proto(pb_name: str) -> None:
-    """Test category conversion from protobuf returns a matching member or int."""
-    pb_value = electrical_components_pb2.ElectricalComponentCategory.Value(pb_name)
-    category = electrical_component_category_from_proto(pb_value)
-    if pb_value in [m.value for m in ElectricalComponentCategory]:
-        assert category is ElectricalComponentCategory(pb_value)
-    else:
-        assert category == pb_value
-
-
-def test_category_from_proto_unknown() -> None:
-    """Test category conversion from protobuf for unknown values returns the int."""
-    category = electrical_component_category_from_proto(UNKNOWN_CATEGORY_PB_VALUE)
-    assert isinstance(category, int)
-    assert category == UNKNOWN_CATEGORY_PB_VALUE
-
-
-@pytest.mark.parametrize(
-    "category", list(ElectricalComponentCategory), ids=lambda m: m.name
-)
-def test_category_to_proto(category: ElectricalComponentCategory) -> None:
-    """Test category conversion to protobuf returns a matching protobuf value."""
-    pb_value = electrical_component_category_to_proto(category)
-    assert pb_value == category.value
-
-
-def test_state_code_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf state code values are not implicitly convertible."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    state_code = list(ElectricalComponentStateCode)[0]
-    _: StateCodeValue = state_code.value  # type: ignore[assignment]
-    electrical_components_pb2.ElectricalComponentStateCode.Name(
-        state_code.value  # type: ignore[arg-type]
-    )
-
-
-@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
-def test_state_code_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf state code names have a matching enum member."""
-    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
-    try:
-        state_code = ElectricalComponentStateCode[
-            pb_name.removeprefix("ELECTRICAL_COMPONENT_STATE_CODE_")
-        ]
-        assert state_code.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
-def test_state_code_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf state code values have a matching enum member."""
-    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
-    try:
-        state_code = ElectricalComponentStateCode(pb_value)
-        assert state_code.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize(
-    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
-)
-def test_state_code_enum_matches_proto_enum_name(
-    state_code: ElectricalComponentStateCode,
-) -> None:
-    """Test that all state code enum members have a matching protobuf enum name."""
-    pb_value = electrical_components_pb2.ElectricalComponentStateCode.ValueType(
-        state_code.value
-    )
-    pb_name = electrical_components_pb2.ElectricalComponentStateCode.Name(pb_value)
-    assert pb_name == f"ELECTRICAL_COMPONENT_STATE_CODE_{state_code.name}"
-
-
-@pytest.mark.parametrize(
-    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
-)
-def test_state_code_enum_matches_proto_enum_value(
-    state_code: ElectricalComponentStateCode,
-) -> None:
-    """Test that all state code enum members have a matching protobuf enum value."""
-    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(
-        f"ELECTRICAL_COMPONENT_STATE_CODE_{state_code.name}"
-    )
-    assert state_code.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", STATE_CODE_PB_NAMES)
-def test_state_code_from_proto(pb_name: str) -> None:
-    """Test state code conversion from protobuf returns a matching member or int."""
-    pb_value = electrical_components_pb2.ElectricalComponentStateCode.Value(pb_name)
-    state_code = electrical_component_state_code_from_proto(pb_value)
-    if pb_value in [m.value for m in ElectricalComponentStateCode]:
-        assert state_code is ElectricalComponentStateCode(pb_value)
-    else:
-        assert state_code == pb_value
-
-
-def test_state_code_from_proto_unknown() -> None:
-    """Test state code conversion from protobuf for unknown values returns the int."""
-    state_code = electrical_component_state_code_from_proto(UNKNOWN_STATE_CODE_PB_VALUE)
-    assert isinstance(state_code, int)
-    assert state_code == UNKNOWN_STATE_CODE_PB_VALUE
-
-
-@pytest.mark.parametrize(
-    "state_code", list(ElectricalComponentStateCode), ids=lambda m: m.name
-)
-def test_state_code_to_proto(state_code: ElectricalComponentStateCode) -> None:
-    """Test state code conversion to protobuf returns a matching protobuf value."""
-    pb_value = electrical_component_state_code_to_proto(state_code)
-    assert pb_value == state_code.value
-
-
-def test_diagnostic_code_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf diagnostic code values are not implicitly convertible."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    diagnostic_code = list(ElectricalComponentDiagnosticCode)[0]
-    _: DiagnosticCodeValue = diagnostic_code.value  # type: ignore[assignment]
-    electrical_components_pb2.ElectricalComponentDiagnosticCode.Name(
-        diagnostic_code.value  # type: ignore[arg-type]
-    )
-
-
-@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
-def test_diagnostic_code_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf diagnostic code names have a matching member."""
-    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
-        pb_name
-    )
-    try:
-        diagnostic_code = ElectricalComponentDiagnosticCode[
-            pb_name.removeprefix("ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_")
-        ]
-        assert diagnostic_code.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
-def test_diagnostic_code_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf diagnostic code values have a matching member."""
-    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
-        pb_name
-    )
-    try:
-        diagnostic_code = ElectricalComponentDiagnosticCode(pb_value)
-        assert diagnostic_code.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in the enum.
-
-
-@pytest.mark.parametrize(
-    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
-)
-def test_diagnostic_code_enum_matches_proto_enum_name(
-    diagnostic_code: ElectricalComponentDiagnosticCode,
-) -> None:
-    """Test that all diagnostic code enum members have a matching protobuf name."""
-    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.ValueType(
-        diagnostic_code.value
-    )
-    pb_name = electrical_components_pb2.ElectricalComponentDiagnosticCode.Name(pb_value)
-    assert pb_name == f"ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_{diagnostic_code.name}"
-
-
-@pytest.mark.parametrize(
-    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
-)
-def test_diagnostic_code_enum_matches_proto_enum_value(
-    diagnostic_code: ElectricalComponentDiagnosticCode,
-) -> None:
-    """Test that all diagnostic code enum members have a matching protobuf value."""
-    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
-        f"ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_{diagnostic_code.name}"
-    )
-    assert diagnostic_code.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", DIAGNOSTIC_CODE_PB_NAMES)
-def test_diagnostic_code_from_proto(pb_name: str) -> None:
-    """Test diagnostic code conversion from protobuf returns a matching member or int."""
-    pb_value = electrical_components_pb2.ElectricalComponentDiagnosticCode.Value(
-        pb_name
-    )
-    diagnostic_code = electrical_component_diagnostic_code_from_proto(pb_value)
-    if pb_value in [m.value for m in ElectricalComponentDiagnosticCode]:
-        assert diagnostic_code is ElectricalComponentDiagnosticCode(pb_value)
-    else:
-        assert diagnostic_code == pb_value
-
-
-def test_diagnostic_code_from_proto_unknown() -> None:
-    """Test diagnostic code conversion from protobuf for unknown values returns the int."""
-    diagnostic_code = electrical_component_diagnostic_code_from_proto(
-        UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE
-    )
-    assert isinstance(diagnostic_code, int)
-    assert diagnostic_code == UNKNOWN_DIAGNOSTIC_CODE_PB_VALUE
-
-
-@pytest.mark.parametrize(
-    "diagnostic_code", list(ElectricalComponentDiagnosticCode), ids=lambda m: m.name
-)
-def test_diagnostic_code_to_proto(
-    diagnostic_code: ElectricalComponentDiagnosticCode,
-) -> None:
-    """Test diagnostic code conversion to protobuf returns a matching value."""
-    pb_value = electrical_component_diagnostic_code_to_proto(diagnostic_code)
-    assert pb_value == diagnostic_code.value
+    python_enum = ElectricalComponentDiagnosticCode
+    proto_enum = electrical_components_pb2.ElectricalComponentDiagnosticCode
+    name_prefix = "ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_"
+    from_proto = staticmethod(electrical_component_diagnostic_code_from_proto)
+    to_proto = staticmethod(electrical_component_diagnostic_code_to_proto)

--- a/tests/streaming/proto/v1alpha8/test_event.py
+++ b/tests/streaming/proto/v1alpha8/test_event.py
@@ -1,13 +1,8 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Tests for Event to/from protobuf v1alpha8 conversion.
+"""Tests for Event to/from protobuf v1alpha8 conversion."""
 
-These tests ensure that, for this version, all enum members are correctly matched by
-name and value between the Python `Event` enum and the protobuf `Event` enum.
-"""
-
-import pytest
 from frequenz.api.common.v1alpha8.streaming import event_pb2
 
 from frequenz.client.common.streaming import Event
@@ -15,79 +10,14 @@ from frequenz.client.common.streaming.proto.v1alpha8 import (
     event_from_proto,
     event_to_proto,
 )
-
-PB_NAMES: list[str] = [m.name for m in event_pb2.Event.DESCRIPTOR.values]
-
-UNKNOWN_PB_VALUE = event_pb2.Event.ValueType(max(m.value for m in Event) + 1)
+from frequenz.client.common.test.enum_parity import EnumParityTest
 
 
-def test_no_implicit_to_proto_conversion() -> None:
-    """Test that protobuf enum values are not implicitly convertible."""
-    # mypy should complain about this assignment, so we ignore the type check here.
-    # If mypy doesn't find an issue with this conversion, it should complain about
-    # the ignore comment having no effect.
-    event = list(Event)[0]
-    _: event_pb2.Event.ValueType = event.value  # type: ignore[assignment]
-    event_pb2.Event.Name(event.value)  # type: ignore[arg-type]
+class TestEventParity(EnumParityTest):
+    """Parity tests for the `Event` enum."""
 
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_name(pb_name: str) -> None:
-    """Test that all known protobuf enum names have a matching Event enum member."""
-    pb_value = event_pb2.Event.Value(pb_name)
-    try:
-        event = Event[pb_name.removeprefix("EVENT_")]
-        assert event.value == pb_value
-    except KeyError:
-        pass  # It is OK to have new protobuf enum values not yet in Event.
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_proto_enum_matches_enum_value(pb_name: str) -> None:
-    """Test that all known protobuf enum values have a matching Event enum member."""
-    pb_value = event_pb2.Event.Value(pb_name)
-    try:
-        event = Event(pb_value)
-        assert event.value == pb_value
-    except ValueError:
-        pass  # It is OK to have new protobuf enum values not yet in Event.
-
-
-@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
-def test_enum_matches_proto_enum_name(event: Event) -> None:
-    """Test that all Event enum members have a matching protobuf enum name."""
-    pb_value = event_pb2.Event.ValueType(event.value)
-    pb_name = event_pb2.Event.Name(pb_value)
-    assert pb_name == f"EVENT_{event.name}"
-
-
-@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
-def test_enum_matches_proto_enum_value(event: Event) -> None:
-    """Test that all Event enum members have a matching protobuf enum value."""
-    pb_value = event_pb2.Event.Value(f"EVENT_{event.name}")
-    assert event.value == pb_value
-
-
-@pytest.mark.parametrize("pb_name", PB_NAMES)
-def test_from_proto(pb_name: str) -> None:
-    """Test conversion from protobuf returns a matching member or the int."""
-    pb_value = event_pb2.Event.Value(pb_name)
-    event = event_from_proto(pb_value)
-    if pb_value in [m.value for m in Event]:
-        assert event is Event(pb_value)
-    else:
-        assert event == pb_value
-
-
-def test_from_proto_unknown() -> None:
-    """Test conversion from protobuf for yet unknown values return the int."""
-    event = event_from_proto(UNKNOWN_PB_VALUE)
-    assert isinstance(event, int)
-    assert event == UNKNOWN_PB_VALUE
-
-
-@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
-def test_to_proto(event: Event) -> None:
-    """Test conversion to protobuf return a matching protobuf value."""
-    pb_value = event_to_proto(event)
-    assert pb_value == event.value
+    python_enum = Event
+    proto_enum = event_pb2.Event
+    name_prefix = "EVENT_"
+    from_proto = staticmethod(event_from_proto)
+    to_proto = staticmethod(event_to_proto)

--- a/tests/streaming/proto/v1alpha8/test_event.py
+++ b/tests/streaming/proto/v1alpha8/test_event.py
@@ -1,0 +1,93 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Event to/from protobuf v1alpha8 conversion.
+
+These tests ensure that, for this version, all enum members are correctly matched by
+name and value between the Python `Event` enum and the protobuf `Event` enum.
+"""
+
+import pytest
+from frequenz.api.common.v1alpha8.streaming import event_pb2
+
+from frequenz.client.common.streaming import Event
+from frequenz.client.common.streaming.proto.v1alpha8 import (
+    event_from_proto,
+    event_to_proto,
+)
+
+PB_NAMES: list[str] = [m.name for m in event_pb2.Event.DESCRIPTOR.values]
+
+UNKNOWN_PB_VALUE = event_pb2.Event.ValueType(max(m.value for m in Event) + 1)
+
+
+def test_no_implicit_to_proto_conversion() -> None:
+    """Test that protobuf enum values are not implicitly convertible."""
+    # mypy should complain about this assignment, so we ignore the type check here.
+    # If mypy doesn't find an issue with this conversion, it should complain about
+    # the ignore comment having no effect.
+    event = list(Event)[0]
+    _: event_pb2.Event.ValueType = event.value  # type: ignore[assignment]
+    event_pb2.Event.Name(event.value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_proto_enum_matches_enum_name(pb_name: str) -> None:
+    """Test that all known protobuf enum names have a matching Event enum member."""
+    pb_value = event_pb2.Event.Value(pb_name)
+    try:
+        event = Event[pb_name.removeprefix("EVENT_")]
+        assert event.value == pb_value
+    except KeyError:
+        pass  # It is OK to have new protobuf enum values not yet in Event.
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_proto_enum_matches_enum_value(pb_name: str) -> None:
+    """Test that all known protobuf enum values have a matching Event enum member."""
+    pb_value = event_pb2.Event.Value(pb_name)
+    try:
+        event = Event(pb_value)
+        assert event.value == pb_value
+    except ValueError:
+        pass  # It is OK to have new protobuf enum values not yet in Event.
+
+
+@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
+def test_enum_matches_proto_enum_name(event: Event) -> None:
+    """Test that all Event enum members have a matching protobuf enum name."""
+    pb_value = event_pb2.Event.ValueType(event.value)
+    pb_name = event_pb2.Event.Name(pb_value)
+    assert pb_name == f"EVENT_{event.name}"
+
+
+@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
+def test_enum_matches_proto_enum_value(event: Event) -> None:
+    """Test that all Event enum members have a matching protobuf enum value."""
+    pb_value = event_pb2.Event.Value(f"EVENT_{event.name}")
+    assert event.value == pb_value
+
+
+@pytest.mark.parametrize("pb_name", PB_NAMES)
+def test_from_proto(pb_name: str) -> None:
+    """Test conversion from protobuf returns a matching member or the int."""
+    pb_value = event_pb2.Event.Value(pb_name)
+    event = event_from_proto(pb_value)
+    if pb_value in [m.value for m in Event]:
+        assert event is Event(pb_value)
+    else:
+        assert event == pb_value
+
+
+def test_from_proto_unknown() -> None:
+    """Test conversion from protobuf for yet unknown values return the int."""
+    event = event_from_proto(UNKNOWN_PB_VALUE)
+    assert isinstance(event, int)
+    assert event == UNKNOWN_PB_VALUE
+
+
+@pytest.mark.parametrize("event", list(Event), ids=lambda m: m.name)
+def test_to_proto(event: Event) -> None:
+    """Test conversion to protobuf return a matching protobuf value."""
+    pb_value = event_to_proto(event)
+    assert pb_value == event.value

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,11 +3,14 @@
 
 """Tests for the frequenz.client.common.streaming package."""
 
-from frequenz.client.common.proto import enum_from_proto
 from frequenz.client.common.streaming import Event
+from frequenz.client.common.streaming.proto.v1alpha8 import (
+    event_from_proto,
+    event_to_proto,
+)
 
 
 def test_event_enum() -> None:
     """Test the Event enum."""
     for event in Event:
-        assert enum_from_proto(event.value, Event) == event
+        assert event_from_proto(event_to_proto(event)) == event


### PR DESCRIPTION
This PR is a followup on #140 and #142. 

It uses plan `int`s as enum values, deprecates implicit conversions, and add explicit conversion functions for the rest of the `v1alpha8` enums: `MetricConnectionCategory`, `ElectricalComponent*` and `Event`.

It also adds new enum values up to api-common 0.8.4 and an utility test class to easily generate the parity tests for all enums.

Part of #141.