### PR TITLE
Add simple electrical component wrappers

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -13,8 +13,12 @@ from ._battery import (
     UnspecifiedBattery,
 )
 from ._category import ElectricalComponentCategory
+from ._chp import Chp
+from ._converter import Converter
+from ._crypto_miner import CryptoMiner
 from ._diagnostic_code import ElectricalComponentDiagnosticCode
 from ._electrical_component import ElectricalComponent
+from ._electrolyzer import Electrolyzer
 from ._ev_charger import (
     AcEvCharger,
     DcEvCharger,
@@ -25,6 +29,7 @@ from ._ev_charger import (
     UnrecognizedEvCharger,
     UnspecifiedEvCharger,
 )
+from ._hvac import Hvac
 from ._ids import ElectricalComponentId
 from ._inverter import (
     BatteryInverter,
@@ -36,13 +41,18 @@ from ._inverter import (
     UnrecognizedInverter,
     UnspecifiedInverter,
 )
+from ._meter import Meter
+from ._precharger import Precharger
 from ._problematic import (
     MismatchedCategoryComponent,
     ProblematicComponent,
     UnrecognizedComponent,
     UnspecifiedComponent,
 )
+from ._relay import Relay
 from ._state_code import ElectricalComponentStateCode
+from ._steam_boiler import SteamBoiler
+from ._wind_turbine import WindTurbine
 
 __all__ = [
     "AcEvCharger",
@@ -50,25 +60,34 @@ __all__ = [
     "BatteryInverter",
     "BatteryType",
     "BatteryTypes",
+    "Chp",
+    "Converter",
+    "CryptoMiner",
     "DcEvCharger",
     "ElectricalComponent",
     "ElectricalComponentCategory",
     "ElectricalComponentDiagnosticCode",
     "ElectricalComponentId",
     "ElectricalComponentStateCode",
+    "Electrolyzer",
     "EvCharger",
     "EvChargerType",
     "EvChargerTypes",
+    "Hvac",
     "HybridEvCharger",
     "HybridInverter",
     "Inverter",
     "InverterType",
     "InverterTypes",
     "LiIonBattery",
+    "Meter",
     "MismatchedCategoryComponent",
     "NaIonBattery",
+    "Precharger",
     "ProblematicComponent",
+    "Relay",
     "SolarInverter",
+    "SteamBoiler",
     "UnrecognizedBattery",
     "UnrecognizedComponent",
     "UnrecognizedEvCharger",
@@ -77,4 +96,5 @@ __all__ = [
     "UnspecifiedComponent",
     "UnspecifiedEvCharger",
     "UnspecifiedInverter",
+    "WindTurbine",
 ]

--- a/src/frequenz/client/common/microgrid/electrical_components/_chp.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_chp.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""CHP component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Chp(Component):
+    """A combined heat and power (CHP) component."""
+
+    category: Literal[ComponentCategory.CHP] = ComponentCategory.CHP
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_chp.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_chp.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,5 @@ from ._electrical_component import ElectricalComponent
 class Chp(ElectricalComponent):
     """A combined heat and power (CHP) electrical component."""
 
-    category: Literal[ComponentCategory.CHP] = ComponentCategory.CHP
+    category: Literal[ElectricalComponentCategory.CHP] = ElectricalComponentCategory.CHP
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_chp.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_chp.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""CHP component."""
+"""CHP electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Chp(Component):
-    """A combined heat and power (CHP) component."""
+class Chp(ElectricalComponent):
+    """A combined heat and power (CHP) electrical component."""
 
     category: Literal[ComponentCategory.CHP] = ComponentCategory.CHP
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_converter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_converter.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Converter component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Converter(Component):
+    """An AC-DC converter component."""
+
+    category: Literal[ComponentCategory.CONVERTER] = ComponentCategory.CONVERTER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_converter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_converter.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Converter component."""
+"""Converter electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Converter(Component):
-    """An AC-DC converter component."""
+class Converter(ElectricalComponent):
+    """An AC-DC converter electrical component."""
 
     category: Literal[ComponentCategory.CONVERTER] = ComponentCategory.CONVERTER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_converter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_converter.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Converter(ElectricalComponent):
     """An AC-DC converter electrical component."""
 
-    category: Literal[ComponentCategory.CONVERTER] = ComponentCategory.CONVERTER
+    category: Literal[ElectricalComponentCategory.CONVERTER] = (
+        ElectricalComponentCategory.CONVERTER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Crypto miner component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CryptoMiner(Component):
+    """A crypto miner component."""
+
+    category: Literal[ComponentCategory.CRYPTO_MINER] = ComponentCategory.CRYPTO_MINER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class CryptoMiner(ElectricalComponent):
     """A crypto miner electrical component."""
 
-    category: Literal[ComponentCategory.CRYPTO_MINER] = ComponentCategory.CRYPTO_MINER
+    category: Literal[ElectricalComponentCategory.CRYPTO_MINER] = (
+        ElectricalComponentCategory.CRYPTO_MINER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_crypto_miner.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Crypto miner component."""
+"""Crypto miner electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class CryptoMiner(Component):
-    """A crypto miner component."""
+class CryptoMiner(ElectricalComponent):
+    """A crypto miner electrical component."""
 
     category: Literal[ComponentCategory.CRYPTO_MINER] = ComponentCategory.CRYPTO_MINER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Electrolyzer component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Electrolyzer(Component):
+    """An electrolyzer component."""
+
+    category: Literal[ComponentCategory.ELECTROLYZER] = ComponentCategory.ELECTROLYZER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Electrolyzer(ElectricalComponent):
     """An electrolyzer electrical component."""
 
-    category: Literal[ComponentCategory.ELECTROLYZER] = ComponentCategory.ELECTROLYZER
+    category: Literal[ElectricalComponentCategory.ELECTROLYZER] = (
+        ElectricalComponentCategory.ELECTROLYZER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrolyzer.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Electrolyzer component."""
+"""Electrolyzer electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Electrolyzer(Component):
-    """An electrolyzer component."""
+class Electrolyzer(ElectricalComponent):
+    """An electrolyzer electrical component."""
 
     category: Literal[ComponentCategory.ELECTROLYZER] = ComponentCategory.ELECTROLYZER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""HVAC component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Hvac(Component):
+    """A heating, ventilation, and air conditioning (HVAC) component."""
+
+    category: Literal[ComponentCategory.HVAC] = ComponentCategory.HVAC
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Hvac(ElectricalComponent):
     """A heating, ventilation, and air conditioning (HVAC) electrical component."""
 
-    category: Literal[ComponentCategory.HVAC] = ComponentCategory.HVAC
+    category: Literal[ElectricalComponentCategory.HVAC] = (
+        ElectricalComponentCategory.HVAC
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_hvac.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""HVAC component."""
+"""HVAC electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Hvac(Component):
-    """A heating, ventilation, and air conditioning (HVAC) component."""
+class Hvac(ElectricalComponent):
+    """A heating, ventilation, and air conditioning (HVAC) electrical component."""
 
     category: Literal[ComponentCategory.HVAC] = ComponentCategory.HVAC
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_meter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_meter.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Meter component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Meter(Component):
+    """A measuring meter component."""
+
+    category: Literal[ComponentCategory.METER] = ComponentCategory.METER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_meter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_meter.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Meter(ElectricalComponent):
     """A measuring meter electrical component."""
 
-    category: Literal[ComponentCategory.METER] = ComponentCategory.METER
+    category: Literal[ElectricalComponentCategory.METER] = (
+        ElectricalComponentCategory.METER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_meter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_meter.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Meter component."""
+"""Meter electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Meter(Component):
-    """A measuring meter component."""
+class Meter(ElectricalComponent):
+    """A measuring meter electrical component."""
 
     category: Literal[ComponentCategory.METER] = ComponentCategory.METER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Precharger component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Precharger(Component):
+    """A precharger component."""
+
+    category: Literal[ComponentCategory.PRECHARGER] = ComponentCategory.PRECHARGER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Precharger component."""
+"""Precharger electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Precharger(Component):
-    """A precharger component."""
+class Precharger(ElectricalComponent):
+    """A precharger electrical component."""
 
     category: Literal[ComponentCategory.PRECHARGER] = ComponentCategory.PRECHARGER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_precharger.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Precharger(ElectricalComponent):
     """A precharger electrical component."""
 
-    category: Literal[ComponentCategory.PRECHARGER] = ComponentCategory.PRECHARGER
+    category: Literal[ElectricalComponentCategory.PRECHARGER] = (
+        ElectricalComponentCategory.PRECHARGER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_relay.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_relay.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Relay component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Relay(Component):
+    """A relay component."""
+
+    category: Literal[ComponentCategory.RELAY] = ComponentCategory.RELAY
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_relay.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_relay.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class Relay(ElectricalComponent):
     """A relay electrical component."""
 
-    category: Literal[ComponentCategory.RELAY] = ComponentCategory.RELAY
+    category: Literal[ElectricalComponentCategory.BREAKER] = (
+        ElectricalComponentCategory.BREAKER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_relay.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_relay.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Relay component."""
+"""Relay electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class Relay(Component):
-    """A relay component."""
+class Relay(ElectricalComponent):
+    """A relay electrical component."""
 
     category: Literal[ComponentCategory.RELAY] = ComponentCategory.RELAY
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Steam boiler component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class SteamBoiler(Component):
+    """A steam boiler component."""
+
+    category: Literal[ComponentCategory.STEAM_BOILER] = ComponentCategory.STEAM_BOILER
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class SteamBoiler(ElectricalComponent):
     """A steam boiler electrical component."""
 
-    category: Literal[ComponentCategory.STEAM_BOILER] = ComponentCategory.STEAM_BOILER
+    category: Literal[ElectricalComponentCategory.STEAM_BOILER] = (
+        ElectricalComponentCategory.STEAM_BOILER
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_steam_boiler.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Steam boiler component."""
+"""Steam boiler electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class SteamBoiler(Component):
-    """A steam boiler component."""
+class SteamBoiler(ElectricalComponent):
+    """A steam boiler electrical component."""
 
     category: Literal[ComponentCategory.STEAM_BOILER] = ComponentCategory.STEAM_BOILER
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
@@ -1,0 +1,18 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Wind turbine component."""
+
+import dataclasses
+from typing import Literal
+
+from ._category import ComponentCategory
+from ._component import Component
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class WindTurbine(Component):
+    """A wind turbine component."""
+
+    category: Literal[ComponentCategory.WIND_TURBINE] = ComponentCategory.WIND_TURBINE
+    """The category of this component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
@@ -6,7 +6,7 @@
 import dataclasses
 from typing import Literal
 
-from ._category import ComponentCategory
+from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
 
@@ -14,5 +14,7 @@ from ._electrical_component import ElectricalComponent
 class WindTurbine(ElectricalComponent):
     """A wind turbine electrical component."""
 
-    category: Literal[ComponentCategory.WIND_TURBINE] = ComponentCategory.WIND_TURBINE
+    category: Literal[ElectricalComponentCategory.WIND_TURBINE] = (
+        ElectricalComponentCategory.WIND_TURBINE
+    )
     """The category of this electrical component."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_wind_turbine.py
@@ -1,18 +1,18 @@
 # License: MIT
 # Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
-"""Wind turbine component."""
+"""Wind turbine electrical component."""
 
 import dataclasses
 from typing import Literal
 
 from ._category import ComponentCategory
-from ._component import Component
+from ._electrical_component import ElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class WindTurbine(Component):
-    """A wind turbine component."""
+class WindTurbine(ElectricalComponent):
+    """A wind turbine electrical component."""
 
     category: Literal[ComponentCategory.WIND_TURBINE] = ComponentCategory.WIND_TURBINE
-    """The category of this component."""
+    """The category of this electrical component."""

--- a/tests/microgrid/electrical_components/test_chp.py
+++ b/tests/microgrid/electrical_components/test_chp.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for CHP component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import Chp, ComponentCategory
+
+
+def test_init() -> None:
+    """Test CHP component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Chp(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="chp_test",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "chp_test"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.CHP

--- a/tests/microgrid/electrical_components/test_chp.py
+++ b/tests/microgrid/electrical_components/test_chp.py
@@ -4,14 +4,16 @@
 """Tests for CHP component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import Chp, ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    Chp,
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+)
 
 
 def test_init() -> None:
     """Test CHP component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Chp(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "chp_test"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.CHP
+    assert component.category == ElectricalComponentCategory.CHP

--- a/tests/microgrid/electrical_components/test_converter.py
+++ b/tests/microgrid/electrical_components/test_converter.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Converter component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Converter
+
+
+def test_init() -> None:
+    """Test Converter component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Converter(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="test_converter",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "test_converter"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.CONVERTER

--- a/tests/microgrid/electrical_components/test_converter.py
+++ b/tests/microgrid/electrical_components/test_converter.py
@@ -4,14 +4,16 @@
 """Tests for Converter component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Converter
+from frequenz.client.common.microgrid.electrical_components import (
+    Converter,
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+)
 
 
 def test_init() -> None:
     """Test Converter component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Converter(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "test_converter"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.CONVERTER
+    assert component.category == ElectricalComponentCategory.CONVERTER

--- a/tests/microgrid/electrical_components/test_crypto_miner.py
+++ b/tests/microgrid/electrical_components/test_crypto_miner.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for CryptoMiner component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, CryptoMiner
+
+
+def test_init() -> None:
+    """Test CryptoMiner component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = CryptoMiner(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="test_crypto_miner",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "test_crypto_miner"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.CRYPTO_MINER

--- a/tests/microgrid/electrical_components/test_crypto_miner.py
+++ b/tests/microgrid/electrical_components/test_crypto_miner.py
@@ -4,14 +4,16 @@
 """Tests for CryptoMiner component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, CryptoMiner
+from frequenz.client.common.microgrid.electrical_components import (
+    CryptoMiner,
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+)
 
 
 def test_init() -> None:
     """Test CryptoMiner component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = CryptoMiner(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "test_crypto_miner"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.CRYPTO_MINER
+    assert component.category == ElectricalComponentCategory.CRYPTO_MINER

--- a/tests/microgrid/electrical_components/test_electrolyzer.py
+++ b/tests/microgrid/electrical_components/test_electrolyzer.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Electrolyzer component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Electrolyzer
+
+
+def test_init() -> None:
+    """Test Electrolyzer component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Electrolyzer(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="test_electrolyzer",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "test_electrolyzer"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.ELECTROLYZER

--- a/tests/microgrid/electrical_components/test_electrolyzer.py
+++ b/tests/microgrid/electrical_components/test_electrolyzer.py
@@ -4,14 +4,16 @@
 """Tests for Electrolyzer component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Electrolyzer
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    Electrolyzer,
+)
 
 
 def test_init() -> None:
     """Test Electrolyzer component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Electrolyzer(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "test_electrolyzer"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.ELECTROLYZER
+    assert component.category == ElectricalComponentCategory.ELECTROLYZER

--- a/tests/microgrid/electrical_components/test_hvac.py
+++ b/tests/microgrid/electrical_components/test_hvac.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for HVAC component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Hvac
+
+
+def test_init() -> None:
+    """Test HVAC component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Hvac(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="test_hvac",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "test_hvac"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.HVAC

--- a/tests/microgrid/electrical_components/test_hvac.py
+++ b/tests/microgrid/electrical_components/test_hvac.py
@@ -4,14 +4,16 @@
 """Tests for HVAC component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Hvac
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    Hvac,
+)
 
 
 def test_init() -> None:
     """Test HVAC component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Hvac(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "test_hvac"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.HVAC
+    assert component.category == ElectricalComponentCategory.HVAC

--- a/tests/microgrid/electrical_components/test_meter.py
+++ b/tests/microgrid/electrical_components/test_meter.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Meter component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Meter
+
+
+def test_init() -> None:
+    """Test Meter component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Meter(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="meter_test",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "meter_test"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.METER

--- a/tests/microgrid/electrical_components/test_meter.py
+++ b/tests/microgrid/electrical_components/test_meter.py
@@ -4,14 +4,16 @@
 """Tests for Meter component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Meter
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    Meter,
+)
 
 
 def test_init() -> None:
     """Test Meter component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Meter(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "meter_test"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.METER
+    assert component.category == ElectricalComponentCategory.METER

--- a/tests/microgrid/electrical_components/test_precharger.py
+++ b/tests/microgrid/electrical_components/test_precharger.py
@@ -4,14 +4,16 @@
 """Tests for Precharger component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Precharger
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    Precharger,
+)
 
 
 def test_init() -> None:
     """Test Precharger component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Precharger(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "precharger_test"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.PRECHARGER
+    assert component.category == ElectricalComponentCategory.PRECHARGER

--- a/tests/microgrid/electrical_components/test_precharger.py
+++ b/tests/microgrid/electrical_components/test_precharger.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Precharger component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Precharger
+
+
+def test_init() -> None:
+    """Test Precharger component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Precharger(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="precharger_test",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "precharger_test"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.PRECHARGER

--- a/tests/microgrid/electrical_components/test_relay.py
+++ b/tests/microgrid/electrical_components/test_relay.py
@@ -4,14 +4,16 @@
 """Tests for Relay component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, Relay
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    Relay,
+)
 
 
 def test_init() -> None:
     """Test Relay component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = Relay(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "relay_test"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.RELAY
+    assert component.category == ElectricalComponentCategory.BREAKER

--- a/tests/microgrid/electrical_components/test_relay.py
+++ b/tests/microgrid/electrical_components/test_relay.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for Relay component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, Relay
+
+
+def test_init() -> None:
+    """Test Relay component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = Relay(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="relay_test",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "relay_test"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.RELAY

--- a/tests/microgrid/electrical_components/test_steam_boiler.py
+++ b/tests/microgrid/electrical_components/test_steam_boiler.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for steam boiler component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, SteamBoiler
+
+
+def test_init() -> None:
+    """Test steam boiler component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = SteamBoiler(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="test_steam_boiler",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "test_steam_boiler"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.STEAM_BOILER

--- a/tests/microgrid/electrical_components/test_steam_boiler.py
+++ b/tests/microgrid/electrical_components/test_steam_boiler.py
@@ -4,14 +4,16 @@
 """Tests for steam boiler component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, SteamBoiler
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    SteamBoiler,
+)
 
 
 def test_init() -> None:
     """Test steam boiler component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = SteamBoiler(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "test_steam_boiler"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.STEAM_BOILER
+    assert component.category == ElectricalComponentCategory.STEAM_BOILER

--- a/tests/microgrid/electrical_components/test_wind_turbine.py
+++ b/tests/microgrid/electrical_components/test_wind_turbine.py
@@ -1,0 +1,29 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for WindTurbine component."""
+
+from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.microgrid.component import ComponentCategory, WindTurbine
+
+
+def test_init() -> None:
+    """Test WindTurbine component initialization."""
+    component_id = ComponentId(1)
+    microgrid_id = MicrogridId(1)
+    component = WindTurbine(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        name="wind_turbine_test",
+        manufacturer="test_manufacturer",
+        model_name="test_model",
+    )
+
+    assert component.id == component_id
+    assert component.microgrid_id == microgrid_id
+    assert component.name == "wind_turbine_test"
+    assert component.manufacturer == "test_manufacturer"
+    assert component.model_name == "test_model"
+    assert component.category == ComponentCategory.WIND_TURBINE

--- a/tests/microgrid/electrical_components/test_wind_turbine.py
+++ b/tests/microgrid/electrical_components/test_wind_turbine.py
@@ -4,14 +4,16 @@
 """Tests for WindTurbine component."""
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-
-from frequenz.client.microgrid.component import ComponentCategory, WindTurbine
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+    ElectricalComponentId,
+    WindTurbine,
+)
 
 
 def test_init() -> None:
     """Test WindTurbine component initialization."""
-    component_id = ComponentId(1)
+    component_id = ElectricalComponentId(1)
     microgrid_id = MicrogridId(1)
     component = WindTurbine(
         id=component_id,
@@ -26,4 +28,4 @@ def test_init() -> None:
     assert component.name == "wind_turbine_test"
     assert component.manufacturer == "test_manufacturer"
     assert component.model_name == "test_model"
-    assert component.category == ComponentCategory.WIND_TURBINE
+    assert component.category == ElectricalComponentCategory.WIND_TURBINE


### PR DESCRIPTION
Import simple leaf component modules from the microgrid client:

- `Chp`
- `Converter`
- `CryptoMiner`
- `Electrolyzer`
- `Hvac`
- `Meter`
- `Precharger`
- `Relay`
- `SteamBoiler`
- `WindTurbine`

These components don't have any extra fields or methods, nor a sub-classes hierarchy, so we import all in one go.

We also adapt the docstrings, modules and tests to the common client layout.

In the future it might be worth having a reusable/parametrized test instead of having the same code copied over and over, but for now we are keeping the tests as they were in the microgrid client.

Part of #203.