### PR TITLE
Add electrical component type aliases

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -54,6 +54,12 @@ from ._problematic import (
 from ._relay import Relay
 from ._state_code import ElectricalComponentStateCode
 from ._steam_boiler import SteamBoiler
+from ._types import (
+    ComponentTypes,
+    ProblematicComponentTypes,
+    UnrecognizedComponentTypes,
+    UnspecifiedComponentTypes,
+)
 from ._wind_turbine import WindTurbine
 
 __all__ = [
@@ -63,6 +69,7 @@ __all__ = [
     "BatteryType",
     "BatteryTypes",
     "Chp",
+    "ComponentTypes",
     "Converter",
     "CryptoMiner",
     "DcEvCharger",
@@ -89,15 +96,18 @@ __all__ = [
     "PowerTransformer",
     "Precharger",
     "ProblematicComponent",
+    "ProblematicComponentTypes",
     "Relay",
     "SolarInverter",
     "SteamBoiler",
     "UnrecognizedBattery",
     "UnrecognizedComponent",
+    "UnrecognizedComponentTypes",
     "UnrecognizedEvCharger",
     "UnrecognizedInverter",
     "UnspecifiedBattery",
     "UnspecifiedComponent",
+    "UnspecifiedComponentTypes",
     "UnspecifiedEvCharger",
     "UnspecifiedInverter",
     "WindTurbine",

--- a/src/frequenz/client/common/microgrid/electrical_components/_types.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_types.py
@@ -1,0 +1,67 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""All known component types."""
+
+from typing import TypeAlias
+
+from ._battery import BatteryTypes, UnrecognizedBattery, UnspecifiedBattery
+from ._chp import Chp
+from ._converter import Converter
+from ._crypto_miner import CryptoMiner
+from ._electrolyzer import Electrolyzer
+from ._ev_charger import EvChargerTypes, UnrecognizedEvCharger, UnspecifiedEvCharger
+from ._grid_connection_point import GridConnectionPoint
+from ._hvac import Hvac
+from ._inverter import InverterTypes, UnrecognizedInverter, UnspecifiedInverter
+from ._meter import Meter
+from ._precharger import Precharger
+from ._problematic import (
+    MismatchedCategoryComponent,
+    UnrecognizedComponent,
+    UnspecifiedComponent,
+)
+from ._relay import Relay
+from ._steam_boiler import SteamBoiler
+from ._voltage_transformer import VoltageTransformer
+from ._wind_turbine import WindTurbine
+
+UnspecifiedComponentTypes: TypeAlias = (
+    UnspecifiedBattery
+    | UnspecifiedComponent
+    | UnspecifiedEvCharger
+    | UnspecifiedInverter
+)
+"""All unspecified component types."""
+
+UnrecognizedComponentTypes: TypeAlias = (
+    UnrecognizedBattery
+    | UnrecognizedComponent
+    | UnrecognizedEvCharger
+    | UnrecognizedInverter
+)
+
+ProblematicComponentTypes: TypeAlias = (
+    MismatchedCategoryComponent | UnrecognizedComponentTypes | UnspecifiedComponentTypes
+)
+"""All possible component types that has a problem."""
+
+ComponentTypes: TypeAlias = (
+    BatteryTypes
+    | Chp
+    | Converter
+    | CryptoMiner
+    | Electrolyzer
+    | EvChargerTypes
+    | GridConnectionPoint
+    | Hvac
+    | InverterTypes
+    | Meter
+    | Precharger
+    | ProblematicComponentTypes
+    | Relay
+    | SteamBoiler
+    | VoltageTransformer
+    | WindTurbine
+)
+"""All possible component types."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_types.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_types.py
@@ -15,6 +15,7 @@ from ._grid_connection_point import GridConnectionPoint
 from ._hvac import Hvac
 from ._inverter import InverterTypes, UnrecognizedInverter, UnspecifiedInverter
 from ._meter import Meter
+from ._power_transformer import PowerTransformer
 from ._precharger import Precharger
 from ._problematic import (
     MismatchedCategoryComponent,
@@ -23,7 +24,6 @@ from ._problematic import (
 )
 from ._relay import Relay
 from ._steam_boiler import SteamBoiler
-from ._voltage_transformer import VoltageTransformer
 from ._wind_turbine import WindTurbine
 
 UnspecifiedComponentTypes: TypeAlias = (
@@ -57,11 +57,11 @@ ComponentTypes: TypeAlias = (
     | Hvac
     | InverterTypes
     | Meter
+    | PowerTransformer
     | Precharger
     | ProblematicComponentTypes
     | Relay
     | SteamBoiler
-    | VoltageTransformer
     | WindTurbine
 )
 """All possible component types."""


### PR DESCRIPTION
Import component type aliases from the microgrid client and adapt them to the common client layout.

Part of #203.