### PR TITLE
Sync `ElectricalComponent` with the protobuf message

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/__init__.py
@@ -45,6 +45,7 @@ from ._inverter import (
     UnspecifiedInverter,
 )
 from ._meter import Meter
+from ._operational_mode import ElectricalComponentOperationalMode
 from ._power_transformer import PowerTransformer
 from ._precharger import Precharger
 from ._problematic import (
@@ -79,6 +80,7 @@ __all__ = [
     "ElectricalComponentConnection",
     "ElectricalComponentDiagnosticCode",
     "ElectricalComponentId",
+    "ElectricalComponentOperationalMode",
     "ElectricalComponentStateCode",
     "ElectricalComponentTypes",
     "Electrolyzer",

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -66,7 +66,7 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     provides telemetry data, accepts control commands, or both.
     """
 
-    rated_bounds: Mapping[Metric | int, Bounds] = dataclasses.field(
+    metric_config_bounds: Mapping[Metric | int, Bounds] = dataclasses.field(
         default_factory=dict,
         # dict is not hashable, so we don't use this field to calculate the hash. This
         # shouldn't be a problem since it is very unlikely that two components with all
@@ -74,7 +74,11 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
         # so hash collisions should be still very unlikely.
         hash=False,
     )
-    """List of rated bounds present for the electrical component identified by Metric."""
+    """The metric configuration bounds for this electrical component, keyed by metric.
+
+    These bounds may be derived from the component configuration, manufacturer
+    limits, or limits of other devices.
+    """
 
     category_specific_metadata: Mapping[str, Any] = dataclasses.field(
         default_factory=dict,

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -13,6 +13,7 @@ from ...types import Lifetime
 from .. import MicrogridId
 from ._category import ElectricalComponentCategory
 from ._ids import ElectricalComponentId
+from ._operational_mode import ElectricalComponentOperationalMode
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -49,6 +50,15 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
 
     operational_lifetime: Lifetime = dataclasses.field(default_factory=Lifetime)
     """The operational lifetime of this electrical component."""
+
+    operational_mode: ElectricalComponentOperationalMode | int = (
+        ElectricalComponentOperationalMode.UNSPECIFIED
+    )
+    """The operational mode of this electrical component.
+
+    This indicates whether the component is active and operational, and whether it
+    provides telemetry data, accepts control commands, or both.
+    """
 
     rated_bounds: Mapping[Metric | int, Bounds] = dataclasses.field(
         default_factory=dict,

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -42,12 +42,6 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     name: str | None = None
     """The name of this electrical component."""
 
-    manufacturer: str | None = None
-    """The manufacturer of this electrical component."""
-
-    model_name: str | None = None
-    """The model name of this electrical component."""
-
     model: str | None = None
     """The model of this electrical component.
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -48,6 +48,12 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     model_name: str | None = None
     """The model name of this electrical component."""
 
+    model: str | None = None
+    """The model of this electrical component.
+
+    This includes both the manufacturer and the model name.
+    """
+
     operational_lifetime: Lifetime = dataclasses.field(default_factory=Lifetime)
     """The operational lifetime of this electrical component."""
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_operational_mode.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_operational_mode.py
@@ -1,0 +1,42 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Electrical component operational modes."""
+
+import enum
+
+
+@enum.unique
+class ElectricalComponentOperationalMode(enum.Enum):
+    """The operational mode of an electrical component.
+
+    This indicates whether the component is active and operational, and whether it
+    provides telemetry data, accepts control commands, or both.
+    """
+
+    UNSPECIFIED = 0
+    """Default value when the operational mode is not explicitly set."""
+
+    INACTIVE = 1
+    """The component is inactive and not operational.
+
+    It does not provide telemetry data, and it does not accept control commands.
+    """
+
+    TELEMETRY_ONLY = 2
+    """The component is active and operational, providing telemetry data only.
+
+    It does not accept control commands.
+    """
+
+    CONTROL_ONLY = 3
+    """The component is active and operational, accepting control commands only.
+
+    It does not provide telemetry data.
+    """
+
+    CONTROL_AND_TELEMETRY = 4
+    """The component is active and operational.
+
+    It provides telemetry data and accepts control commands.
+    """

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
@@ -19,6 +19,10 @@ from ._electrical_component_connection import (
     electrical_component_connection_from_proto,
     electrical_component_connection_from_proto_with_issues,
 )
+from ._operational_mode import (
+    electrical_component_operational_mode_from_proto,
+    electrical_component_operational_mode_to_proto,
+)
 from ._state_code import (
     electrical_component_state_code_from_proto,
     electrical_component_state_code_to_proto,
@@ -33,6 +37,8 @@ __all__ = [
     "electrical_component_diagnostic_code_to_proto",
     "electrical_component_from_proto",
     "electrical_component_from_proto_with_issues",
+    "electrical_component_operational_mode_from_proto",
+    "electrical_component_operational_mode_to_proto",
     "electrical_component_state_code_from_proto",
     "electrical_component_state_code_to_proto",
 ]

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -111,7 +111,7 @@ class _ElectricalComponentBaseData(NamedTuple):
     model: str | None
     category: ElectricalComponentCategory | int
     lifetime: Lifetime
-    rated_bounds: dict[Metric | int, Bounds]
+    metric_config_bounds: dict[Metric | int, Bounds]
     category_specific_info: dict[str, Any]
     operational_mode: ElectricalComponentOperationalMode | int
     category_mismatched: bool = False
@@ -161,7 +161,7 @@ def _electrical_component_base_from_proto_with_issues(
         message, major_issues=major_issues, minor_issues=minor_issues
     )
 
-    rated_bounds = _metric_config_bounds_from_proto(
+    metric_config_bounds = _metric_config_bounds_from_proto(
         message.metric_config_bounds,
         major_issues=major_issues,
         minor_issues=minor_issues,
@@ -202,7 +202,7 @@ def _electrical_component_base_from_proto_with_issues(
         model,
         category,
         lifetime,
-        rated_bounds,
+        metric_config_bounds,
         category_specific_info,
         operational_mode,
         category_mismatched,
@@ -242,7 +242,7 @@ def electrical_component_from_proto_with_issues(
             operational_lifetime=base_data.lifetime,
             operational_mode=base_data.operational_mode,
             category_specific_metadata=base_data.category_specific_info,
-            rated_bounds=base_data.rated_bounds,
+            metric_config_bounds=base_data.metric_config_bounds,
         )
 
     match base_data.category:
@@ -257,7 +257,7 @@ def electrical_component_from_proto_with_issues(
                 category=base_data.category,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
-                rated_bounds=base_data.rated_bounds,
+                metric_config_bounds=base_data.metric_config_bounds,
             )
         case (
             ElectricalComponentCategory.UNSPECIFIED
@@ -281,7 +281,7 @@ def electrical_component_from_proto_with_issues(
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
-                rated_bounds=base_data.rated_bounds,
+                metric_config_bounds=base_data.metric_config_bounds,
             )
         case ElectricalComponentCategory.BATTERY:
             battery_enum_to_class: dict[
@@ -307,7 +307,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                     )
                 case int():
                     major_issues.append(f"battery type {battery_type} is unrecognized")
@@ -320,7 +320,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                         type=battery_type,
                     )
                 case unexpected_battery_type:
@@ -358,7 +358,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                     )
                 case int():
                     major_issues.append(
@@ -373,7 +373,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                         type=ev_charger_type,
                     )
                 case unexpected_ev_charger_type:
@@ -392,7 +392,7 @@ def electrical_component_from_proto_with_issues(
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
-                rated_bounds=base_data.rated_bounds,
+                metric_config_bounds=base_data.metric_config_bounds,
                 rated_fuse_current=rated_fuse_current,
             )
         case ElectricalComponentCategory.INVERTER:
@@ -428,7 +428,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                     )
                 case int():
                     major_issues.append(
@@ -443,7 +443,7 @@ def electrical_component_from_proto_with_issues(
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
-                        rated_bounds=base_data.rated_bounds,
+                        metric_config_bounds=base_data.metric_config_bounds,
                         type=inverter_type,
                     )
                 case unexpected_inverter_type:
@@ -458,7 +458,7 @@ def electrical_component_from_proto_with_issues(
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
-                rated_bounds=base_data.rated_bounds,
+                metric_config_bounds=base_data.metric_config_bounds,
                 primary_voltage=message.category_specific_info.power_transformer.primary,
                 secondary_voltage=message.category_specific_info.power_transformer.secondary,
             )
@@ -482,7 +482,7 @@ def electrical_component_from_proto_with_issues(
                 category=base_data.category.value,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
-                rated_bounds=base_data.rated_bounds,
+                metric_config_bounds=base_data.metric_config_bounds,
             )
         case unexpected_category:
             assert_never(unexpected_category)

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -29,6 +29,7 @@ from ... import (
     DcEvCharger,
     ElectricalComponentCategory,
     ElectricalComponentId,
+    ElectricalComponentOperationalMode,
     ElectricalComponentTypes,
     Electrolyzer,
     EvChargerType,
@@ -55,6 +56,7 @@ from ... import (
     UnspecifiedInverter,
     WindTurbine,
 )
+from ._operational_mode import electrical_component_operational_mode_from_proto
 
 _logger = logging.getLogger(__name__)
 
@@ -110,6 +112,7 @@ class _ElectricalComponentBaseData(NamedTuple):
     lifetime: Lifetime
     rated_bounds: dict[Metric | int, Bounds]
     category_specific_info: dict[str, Any]
+    operational_mode: ElectricalComponentOperationalMode | int
     category_mismatched: bool = False
 
 
@@ -143,6 +146,10 @@ def _electrical_component_base_from_proto_with_issues(
     model_name = message.model_name or None
     if model_name is None:
         minor_issues.append("model_name is empty")
+
+    operational_mode = electrical_component_operational_mode_from_proto(
+        message.operational_mode
+    )
 
     lifetime = _get_operational_lifetime_from_proto(
         message, major_issues=major_issues, minor_issues=minor_issues
@@ -190,6 +197,7 @@ def _electrical_component_base_from_proto_with_issues(
         lifetime,
         rated_bounds,
         category_specific_info,
+        operational_mode,
         category_mismatched,
     )
 
@@ -224,6 +232,7 @@ def electrical_component_from_proto_with_issues(
             model_name=base_data.model_name,
             category=base_data.category,
             operational_lifetime=base_data.lifetime,
+            operational_mode=base_data.operational_mode,
             category_specific_metadata=base_data.category_specific_info,
             rated_bounds=base_data.rated_bounds,
         )
@@ -238,6 +247,7 @@ def electrical_component_from_proto_with_issues(
                 model_name=base_data.model_name,
                 category=base_data.category,
                 operational_lifetime=base_data.lifetime,
+                operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
             )
         case (
@@ -260,6 +270,7 @@ def electrical_component_from_proto_with_issues(
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
                 operational_lifetime=base_data.lifetime,
+                operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
             )
         case ElectricalComponentCategory.BATTERY:
@@ -284,6 +295,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                     )
                 case int():
@@ -295,6 +307,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                         type=battery_type,
                     )
@@ -331,6 +344,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                     )
                 case int():
@@ -344,6 +358,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                         type=ev_charger_type,
                     )
@@ -361,6 +376,7 @@ def electrical_component_from_proto_with_issues(
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
                 operational_lifetime=base_data.lifetime,
+                operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
                 rated_fuse_current=rated_fuse_current,
             )
@@ -395,6 +411,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                     )
                 case int():
@@ -408,6 +425,7 @@ def electrical_component_from_proto_with_issues(
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
                         operational_lifetime=base_data.lifetime,
+                        operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
                         type=inverter_type,
                     )
@@ -421,6 +439,7 @@ def electrical_component_from_proto_with_issues(
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
                 operational_lifetime=base_data.lifetime,
+                operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
                 primary_voltage=message.category_specific_info.power_transformer.primary,
                 secondary_voltage=message.category_specific_info.power_transformer.secondary,
@@ -443,6 +462,7 @@ def electrical_component_from_proto_with_issues(
                 model_name=base_data.model_name,
                 category=base_data.category.value,
                 operational_lifetime=base_data.lifetime,
+                operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
             )
         case unexpected_category:

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -106,8 +106,6 @@ class _ElectricalComponentBaseData(NamedTuple):
     component_id: ElectricalComponentId
     microgrid_id: MicrogridId
     name: str | None
-    manufacturer: str | None
-    model_name: str | None
     model: str | None
     category: ElectricalComponentCategory | int
     lifetime: Lifetime
@@ -140,14 +138,6 @@ def _electrical_component_base_from_proto_with_issues(
     name = message.name or None
     if name is None:
         minor_issues.append("name is empty")
-
-    manufacturer = message.manufacturer or None
-    if manufacturer is None:
-        minor_issues.append("manufacturer is empty")
-
-    model_name = message.model_name or None
-    if model_name is None:
-        minor_issues.append("model_name is empty")
 
     model = message.model or None
     if model is None:
@@ -197,8 +187,6 @@ def _electrical_component_base_from_proto_with_issues(
         component_id,
         microgrid_id,
         name,
-        manufacturer,
-        model_name,
         model,
         category,
         lifetime,
@@ -235,8 +223,6 @@ def electrical_component_from_proto_with_issues(
             id=base_data.component_id,
             microgrid_id=base_data.microgrid_id,
             name=base_data.name,
-            manufacturer=base_data.manufacturer,
-            model_name=base_data.model_name,
             model=base_data.model,
             category=base_data.category,
             operational_lifetime=base_data.lifetime,
@@ -251,8 +237,6 @@ def electrical_component_from_proto_with_issues(
                 id=base_data.component_id,
                 microgrid_id=base_data.microgrid_id,
                 name=base_data.name,
-                manufacturer=base_data.manufacturer,
-                model_name=base_data.model_name,
                 model=base_data.model,
                 category=base_data.category,
                 operational_lifetime=base_data.lifetime,
@@ -276,8 +260,6 @@ def electrical_component_from_proto_with_issues(
                 id=base_data.component_id,
                 microgrid_id=base_data.microgrid_id,
                 name=base_data.name,
-                manufacturer=base_data.manufacturer,
-                model_name=base_data.model_name,
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
@@ -302,8 +284,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -315,8 +295,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -353,8 +331,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -368,8 +344,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -387,8 +361,6 @@ def electrical_component_from_proto_with_issues(
                 id=base_data.component_id,
                 microgrid_id=base_data.microgrid_id,
                 name=base_data.name,
-                manufacturer=base_data.manufacturer,
-                model_name=base_data.model_name,
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
@@ -423,8 +395,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -438,8 +408,6 @@ def electrical_component_from_proto_with_issues(
                         id=base_data.component_id,
                         microgrid_id=base_data.microgrid_id,
                         name=base_data.name,
-                        manufacturer=base_data.manufacturer,
-                        model_name=base_data.model_name,
                         model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
@@ -453,8 +421,6 @@ def electrical_component_from_proto_with_issues(
                 id=base_data.component_id,
                 microgrid_id=base_data.microgrid_id,
                 name=base_data.name,
-                manufacturer=base_data.manufacturer,
-                model_name=base_data.model_name,
                 model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
@@ -476,8 +442,6 @@ def electrical_component_from_proto_with_issues(
                 id=base_data.component_id,
                 microgrid_id=base_data.microgrid_id,
                 name=base_data.name,
-                manufacturer=base_data.manufacturer,
-                model_name=base_data.model_name,
                 model=base_data.model,
                 category=base_data.category.value,
                 operational_lifetime=base_data.lifetime,

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -108,6 +108,7 @@ class _ElectricalComponentBaseData(NamedTuple):
     name: str | None
     manufacturer: str | None
     model_name: str | None
+    model: str | None
     category: ElectricalComponentCategory | int
     lifetime: Lifetime
     rated_bounds: dict[Metric | int, Bounds]
@@ -116,6 +117,7 @@ class _ElectricalComponentBaseData(NamedTuple):
     category_mismatched: bool = False
 
 
+# pylint: disable-next=too-many-locals
 def _electrical_component_base_from_proto_with_issues(
     message: electrical_components_pb2.ElectricalComponent,
     *,
@@ -146,6 +148,10 @@ def _electrical_component_base_from_proto_with_issues(
     model_name = message.model_name or None
     if model_name is None:
         minor_issues.append("model_name is empty")
+
+    model = message.model or None
+    if model is None:
+        minor_issues.append("model is empty")
 
     operational_mode = electrical_component_operational_mode_from_proto(
         message.operational_mode
@@ -193,6 +199,7 @@ def _electrical_component_base_from_proto_with_issues(
         name,
         manufacturer,
         model_name,
+        model,
         category,
         lifetime,
         rated_bounds,
@@ -230,6 +237,7 @@ def electrical_component_from_proto_with_issues(
             name=base_data.name,
             manufacturer=base_data.manufacturer,
             model_name=base_data.model_name,
+            model=base_data.model,
             category=base_data.category,
             operational_lifetime=base_data.lifetime,
             operational_mode=base_data.operational_mode,
@@ -245,6 +253,7 @@ def electrical_component_from_proto_with_issues(
                 name=base_data.name,
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
+                model=base_data.model,
                 category=base_data.category,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
@@ -269,6 +278,7 @@ def electrical_component_from_proto_with_issues(
                 name=base_data.name,
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
+                model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
@@ -294,6 +304,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -306,6 +317,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -343,6 +355,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -357,6 +370,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -375,6 +389,7 @@ def electrical_component_from_proto_with_issues(
                 name=base_data.name,
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
+                model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
@@ -410,6 +425,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -424,6 +440,7 @@ def electrical_component_from_proto_with_issues(
                         name=base_data.name,
                         manufacturer=base_data.manufacturer,
                         model_name=base_data.model_name,
+                        model=base_data.model,
                         operational_lifetime=base_data.lifetime,
                         operational_mode=base_data.operational_mode,
                         rated_bounds=base_data.rated_bounds,
@@ -438,6 +455,7 @@ def electrical_component_from_proto_with_issues(
                 name=base_data.name,
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
+                model=base_data.model,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,
                 rated_bounds=base_data.rated_bounds,
@@ -460,6 +478,7 @@ def electrical_component_from_proto_with_issues(
                 name=base_data.name,
                 manufacturer=base_data.manufacturer,
                 model_name=base_data.model_name,
+                model=base_data.model,
                 category=base_data.category.value,
                 operational_lifetime=base_data.lifetime,
                 operational_mode=base_data.operational_mode,

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_operational_mode.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_operational_mode.py
@@ -1,0 +1,42 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of electrical component operational modes to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from .....proto import enum_from_proto
+from ... import ElectricalComponentOperationalMode
+
+
+def electrical_component_operational_mode_from_proto(
+    message: electrical_components_pb2.ElectricalComponentOperationalMode.ValueType,
+) -> ElectricalComponentOperationalMode | int:
+    """Convert a protobuf ElectricalComponentOperationalMode enum value to an enum member.
+
+    Args:
+        message: A protobuf ElectricalComponentOperationalMode enum value.
+
+    Returns:
+        The corresponding ElectricalComponentOperationalMode enum member, or the raw
+            `int` if the protobuf value is not recognized.
+    """
+    return enum_from_proto(message, ElectricalComponentOperationalMode)
+
+
+def electrical_component_operational_mode_to_proto(
+    operational_mode: ElectricalComponentOperationalMode,
+) -> electrical_components_pb2.ElectricalComponentOperationalMode.ValueType:
+    """Convert an ElectricalComponentOperationalMode enum member to a protobuf enum value.
+
+    Args:
+        operational_mode: An ElectricalComponentOperationalMode enum member.
+
+    Returns:
+        The corresponding protobuf ElectricalComponentOperationalMode enum value.
+    """
+    return electrical_components_pb2.ElectricalComponentOperationalMode.ValueType(
+        operational_mode.value
+    )

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -65,7 +65,7 @@ def default_component_base_data(
         model=DEFAULT_MODEL,
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=DEFAULT_LIFETIME,
-        rated_bounds={Metric.AC_ENERGY_ACTIVE: Bounds(lower=0, upper=100)},
+        metric_config_bounds={Metric.AC_ENERGY_ACTIVE: Bounds(lower=0, upper=100)},
         category_specific_info={},
         operational_mode=ElectricalComponentOperationalMode.CONTROL_AND_TELEMETRY,
         category_mismatched=False,
@@ -85,7 +85,7 @@ def assert_base_data(
     assert base_data.category == other.category
     assert base_data.lifetime == other.operational_lifetime
     assert base_data.operational_mode == other.operational_mode
-    assert base_data.rated_bounds == other.rated_bounds
+    assert base_data.metric_config_bounds == other.metric_config_bounds
     assert base_data.category_specific_info == other.category_specific_metadata
 
 
@@ -122,8 +122,8 @@ def base_data_as_proto(
                 base_data.lifetime.end_time
             )
         proto.operational_lifetime.CopyFrom(lifetime_pb2.Lifetime(**lifetime_dict))
-    if base_data.rated_bounds:
-        for metric, bounds in base_data.rated_bounds.items():
+    if base_data.metric_config_bounds:
+        for metric, bounds in base_data.metric_config_bounds.items():
             bounds_dict: dict[str, float] = {}
             if bounds.lower is not None:
                 bounds_dict["lower"] = bounds.lower

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -36,6 +36,7 @@ DEFAULT_MICROGRID_ID = MicrogridId(1)
 DEFAULT_NAME = "test_component"
 DEFAULT_MANUFACTURER = "test_manufacturer"
 DEFAULT_MODEL_NAME = "test_model"
+DEFAULT_MODEL = "test_manufacturer test_model"
 
 
 @pytest.fixture
@@ -61,6 +62,7 @@ def default_component_base_data(
         name=DEFAULT_NAME,
         manufacturer=DEFAULT_MANUFACTURER,
         model_name=DEFAULT_MODEL_NAME,
+        model=DEFAULT_MODEL,
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=DEFAULT_LIFETIME,
         rated_bounds={Metric.AC_ENERGY_ACTIVE: Bounds(lower=0, upper=100)},
@@ -79,6 +81,7 @@ def assert_base_data(
     assert base_data.name == other.name
     assert base_data.manufacturer == other.manufacturer
     assert base_data.model_name == other.model_name
+    assert base_data.model == other.model
     assert base_data.category == other.category
     assert base_data.lifetime == other.operational_lifetime
     assert base_data.operational_mode == other.operational_mode
@@ -96,6 +99,7 @@ def base_data_as_proto(
         name=base_data.name or "",
         manufacturer=base_data.manufacturer or "",
         model_name=base_data.model_name or "",
+        model=base_data.model or "",
         category=(
             base_data.category
             if isinstance(base_data.category, int)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -19,6 +19,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponent,
     ElectricalComponentCategory,
     ElectricalComponentId,
+    ElectricalComponentOperationalMode,
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8._electrical_component import (  # noqa: E501
     _ElectricalComponentBaseData,
@@ -64,6 +65,7 @@ def default_component_base_data(
         lifetime=DEFAULT_LIFETIME,
         rated_bounds={Metric.AC_ENERGY_ACTIVE: Bounds(lower=0, upper=100)},
         category_specific_info={},
+        operational_mode=ElectricalComponentOperationalMode.CONTROL_AND_TELEMETRY,
         category_mismatched=False,
     )
 
@@ -79,6 +81,7 @@ def assert_base_data(
     assert base_data.model_name == other.model_name
     assert base_data.category == other.category
     assert base_data.lifetime == other.operational_lifetime
+    assert base_data.operational_mode == other.operational_mode
     assert base_data.rated_bounds == other.rated_bounds
     assert base_data.category_specific_info == other.category_specific_metadata
 
@@ -97,6 +100,11 @@ def base_data_as_proto(
             base_data.category
             if isinstance(base_data.category, int)
             else int(base_data.category.value)  # type: ignore[arg-type]
+        ),
+        operational_mode=(
+            base_data.operational_mode
+            if isinstance(base_data.operational_mode, int)
+            else int(base_data.operational_mode.value)  # type: ignore[arg-type]
         ),
     )
     if base_data.lifetime:

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -34,8 +34,6 @@ DEFAULT_LIFETIME = Lifetime(
 DEFAULT_COMPONENT_ID = ElectricalComponentId(42)
 DEFAULT_MICROGRID_ID = MicrogridId(1)
 DEFAULT_NAME = "test_component"
-DEFAULT_MANUFACTURER = "test_manufacturer"
-DEFAULT_MODEL_NAME = "test_model"
 DEFAULT_MODEL = "test_manufacturer test_model"
 
 
@@ -60,8 +58,6 @@ def default_component_base_data(
         component_id=component_id,
         microgrid_id=microgrid_id,
         name=DEFAULT_NAME,
-        manufacturer=DEFAULT_MANUFACTURER,
-        model_name=DEFAULT_MODEL_NAME,
         model=DEFAULT_MODEL,
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=DEFAULT_LIFETIME,
@@ -79,8 +75,6 @@ def assert_base_data(
     assert base_data.component_id == other.id
     assert base_data.microgrid_id == other.microgrid_id
     assert base_data.name == other.name
-    assert base_data.manufacturer == other.manufacturer
-    assert base_data.model_name == other.model_name
     assert base_data.model == other.model
     assert base_data.category == other.category
     assert base_data.lifetime == other.operational_lifetime
@@ -97,8 +91,6 @@ def base_data_as_proto(
         id=int(base_data.component_id),
         microgrid_id=int(base_data.microgrid_id),
         name=base_data.name or "",
-        manufacturer=base_data.manufacturer or "",
-        model_name=base_data.model_name or "",
         model=base_data.model or "",
         category=(
             base_data.category

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -49,7 +49,7 @@ def test_missing_category_specific_info(
         model_name=None,
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=Lifetime(),
-        rated_bounds={},
+        metric_config_bounds={},
         category_specific_info={},
     )
     proto = base_data_as_proto(base_data)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -45,8 +45,6 @@ def test_missing_category_specific_info(
     minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         name=None,
-        manufacturer=None,
-        model_name=None,
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=Lifetime(),
         metric_config_bounds={},
@@ -64,8 +62,6 @@ def test_missing_category_specific_info(
     assert sorted(minor_issues) == sorted(
         [
             "name is empty",
-            "manufacturer is empty",
-            "model_name is empty",
             "missing operational lifetime, considering it always operational",
         ]
     )

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_operational_mode.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_operational_mode.py
@@ -1,0 +1,27 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for electrical component operational mode to/from protobuf v1alpha8 conversion."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentOperationalMode,
+)
+from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
+    electrical_component_operational_mode_from_proto,
+    electrical_component_operational_mode_to_proto,
+)
+from frequenz.client.common.test.enum_parity import EnumParityTest
+
+
+class TestElectricalComponentOperationalModeParity(EnumParityTest):
+    """Parity tests for the `ElectricalComponentOperationalMode` enum."""
+
+    python_enum = ElectricalComponentOperationalMode
+    proto_enum = electrical_components_pb2.ElectricalComponentOperationalMode
+    name_prefix = "ELECTRICAL_COMPONENT_OPERATIONAL_MODE_"
+    from_proto = staticmethod(electrical_component_operational_mode_from_proto)
+    to_proto = staticmethod(electrical_component_operational_mode_to_proto)

--- a/tests/microgrid/electrical_components/test_battery.py
+++ b/tests/microgrid/electrical_components/test_battery.py
@@ -50,8 +50,6 @@ def test_abstract_battery_cannot_be_instantiated(
             id=component_id,
             microgrid_id=microgrid_id,
             name="test_battery",
-            manufacturer="test_manufacturer",
-            model_name="test_model",
             type=BatteryType.LI_ION,
         )
 
@@ -83,15 +81,11 @@ def test_recognized_battery_types(
         id=component_id,
         microgrid_id=microgrid_id,
         name=case.name,
-        manufacturer="test_manufacturer",
-        model_name="test_model",
     )
 
     assert battery.id == component_id
     assert battery.microgrid_id == microgrid_id
     assert battery.name == case.name
-    assert battery.manufacturer == "test_manufacturer"
-    assert battery.model_name == "test_model"
     assert battery.category == ElectricalComponentCategory.BATTERY
     assert battery.type == case.expected_type
 
@@ -104,15 +98,11 @@ def test_unrecognized_battery_type(
         id=component_id,
         microgrid_id=microgrid_id,
         name="unrecognized_battery",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         type=999,
     )
 
     assert battery.id == component_id
     assert battery.microgrid_id == microgrid_id
     assert battery.name == "unrecognized_battery"
-    assert battery.manufacturer == "test_manufacturer"
-    assert battery.model_name == "test_model"
     assert battery.category == ElectricalComponentCategory.BATTERY
     assert battery.type == 999

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -49,8 +49,6 @@ def test_creation_with_defaults() -> None:
     )
 
     assert component.name is None
-    assert component.manufacturer is None
-    assert component.model_name is None
     assert component.model is None
     assert component.operational_lifetime == Lifetime()
     assert component.operational_mode == ElectricalComponentOperationalMode.UNSPECIFIED
@@ -69,16 +67,12 @@ def test_creation_full() -> None:
         microgrid_id=MicrogridId(2),
         category=ElectricalComponentCategory.UNSPECIFIED,
         name="test-component",
-        manufacturer="Test Manufacturer",
-        model_name="Test Model",
         model="Test Manufacturer Test Model",
         metric_config_bounds=metric_config_bounds,
         category_specific_metadata=metadata,
     )
 
     assert component.name == "test-component"
-    assert component.manufacturer == "Test Manufacturer"
-    assert component.model_name == "Test Model"
     assert component.model == "Test Manufacturer Test Model"
     assert component.metric_config_bounds == metric_config_bounds
     assert component.category_specific_metadata == metadata
@@ -151,8 +145,6 @@ COMPONENT = _TestElectricalComponent(
     microgrid_id=MicrogridId(1),
     category=ElectricalComponentCategory.UNSPECIFIED,
     name="test",
-    manufacturer="Test Mfg",
-    model_name="Model A",
     metric_config_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-100.0, upper=100.0)},
     category_specific_metadata={"key": "value"},
 )
@@ -162,8 +154,6 @@ DIFFERENT_NONHASHABLE = _TestElectricalComponent(
     microgrid_id=COMPONENT.microgrid_id,
     category=COMPONENT.category,
     name=COMPONENT.name,
-    manufacturer=COMPONENT.manufacturer,
-    model_name=COMPONENT.model_name,
     metric_config_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-200.0, upper=200.0)},
     category_specific_metadata={"different": "metadata"},
 )
@@ -173,8 +163,6 @@ DIFFERENT_NAME = _TestElectricalComponent(
     microgrid_id=COMPONENT.microgrid_id,
     category=COMPONENT.category,
     name="different",
-    manufacturer=COMPONENT.manufacturer,
-    model_name=COMPONENT.model_name,
     metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
@@ -184,8 +172,6 @@ DIFFERENT_ID = _TestElectricalComponent(
     microgrid_id=COMPONENT.microgrid_id,
     category=COMPONENT.category,
     name=COMPONENT.name,
-    manufacturer=COMPONENT.manufacturer,
-    model_name=COMPONENT.model_name,
     metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
@@ -195,8 +181,6 @@ DIFFERENT_MICROGRID_ID = _TestElectricalComponent(
     microgrid_id=MicrogridId(2),
     category=COMPONENT.category,
     name=COMPONENT.name,
-    manufacturer=COMPONENT.manufacturer,
-    model_name=COMPONENT.model_name,
     metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
@@ -206,8 +190,6 @@ DIFFERENT_BOTH_ID = _TestElectricalComponent(
     microgrid_id=MicrogridId(2),
     category=COMPONENT.category,
     name=COMPONENT.name,
-    manufacturer=COMPONENT.manufacturer,
-    model_name=COMPONENT.model_name,
     metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -51,6 +51,7 @@ def test_creation_with_defaults() -> None:
     assert component.name is None
     assert component.manufacturer is None
     assert component.model_name is None
+    assert component.model is None
     assert component.operational_lifetime == Lifetime()
     assert component.operational_mode == ElectricalComponentOperationalMode.UNSPECIFIED
     assert component.rated_bounds == {}
@@ -70,6 +71,7 @@ def test_creation_full() -> None:
         name="test-component",
         manufacturer="Test Manufacturer",
         model_name="Test Model",
+        model="Test Manufacturer Test Model",
         rated_bounds=rated_bounds,
         category_specific_metadata=metadata,
     )
@@ -77,6 +79,7 @@ def test_creation_full() -> None:
     assert component.name == "test-component"
     assert component.manufacturer == "Test Manufacturer"
     assert component.model_name == "Test Model"
+    assert component.model == "Test Manufacturer Test Model"
     assert component.rated_bounds == rated_bounds
     assert component.category_specific_metadata == metadata
 

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -15,6 +15,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponent,
     ElectricalComponentCategory,
     ElectricalComponentId,
+    ElectricalComponentOperationalMode,
 )
 from frequenz.client.common.types import Lifetime
 
@@ -51,6 +52,7 @@ def test_creation_with_defaults() -> None:
     assert component.manufacturer is None
     assert component.model_name is None
     assert component.operational_lifetime == Lifetime()
+    assert component.operational_mode == ElectricalComponentOperationalMode.UNSPECIFIED
     assert component.rated_bounds == {}
     assert component.category_specific_metadata == {}
 

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -54,14 +54,14 @@ def test_creation_with_defaults() -> None:
     assert component.model is None
     assert component.operational_lifetime == Lifetime()
     assert component.operational_mode == ElectricalComponentOperationalMode.UNSPECIFIED
-    assert component.rated_bounds == {}
+    assert component.metric_config_bounds == {}
     assert component.category_specific_metadata == {}
 
 
 def test_creation_full() -> None:
     """Test electrical component creation with all attributes."""
     bounds = Bounds(lower=-100.0, upper=100.0)
-    rated_bounds: dict[Metric | int, Bounds] = {Metric.AC_POWER_ACTIVE: bounds}
+    metric_config_bounds: dict[Metric | int, Bounds] = {Metric.AC_POWER_ACTIVE: bounds}
     metadata = {"key1": "value1", "key2": 42}
 
     component = _TestElectricalComponent(
@@ -72,7 +72,7 @@ def test_creation_full() -> None:
         manufacturer="Test Manufacturer",
         model_name="Test Model",
         model="Test Manufacturer Test Model",
-        rated_bounds=rated_bounds,
+        metric_config_bounds=metric_config_bounds,
         category_specific_metadata=metadata,
     )
 
@@ -80,7 +80,7 @@ def test_creation_full() -> None:
     assert component.manufacturer == "Test Manufacturer"
     assert component.model_name == "Test Model"
     assert component.model == "Test Manufacturer Test Model"
-    assert component.rated_bounds == rated_bounds
+    assert component.metric_config_bounds == metric_config_bounds
     assert component.category_specific_metadata == metadata
 
 
@@ -153,7 +153,7 @@ COMPONENT = _TestElectricalComponent(
     name="test",
     manufacturer="Test Mfg",
     model_name="Model A",
-    rated_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-100.0, upper=100.0)},
+    metric_config_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-100.0, upper=100.0)},
     category_specific_metadata={"key": "value"},
 )
 
@@ -164,7 +164,7 @@ DIFFERENT_NONHASHABLE = _TestElectricalComponent(
     name=COMPONENT.name,
     manufacturer=COMPONENT.manufacturer,
     model_name=COMPONENT.model_name,
-    rated_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-200.0, upper=200.0)},
+    metric_config_bounds={Metric.AC_POWER_ACTIVE: Bounds(lower=-200.0, upper=200.0)},
     category_specific_metadata={"different": "metadata"},
 )
 
@@ -175,7 +175,7 @@ DIFFERENT_NAME = _TestElectricalComponent(
     name="different",
     manufacturer=COMPONENT.manufacturer,
     model_name=COMPONENT.model_name,
-    rated_bounds=COMPONENT.rated_bounds,
+    metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
 
@@ -186,7 +186,7 @@ DIFFERENT_ID = _TestElectricalComponent(
     name=COMPONENT.name,
     manufacturer=COMPONENT.manufacturer,
     model_name=COMPONENT.model_name,
-    rated_bounds=COMPONENT.rated_bounds,
+    metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
 
@@ -197,7 +197,7 @@ DIFFERENT_MICROGRID_ID = _TestElectricalComponent(
     name=COMPONENT.name,
     manufacturer=COMPONENT.manufacturer,
     model_name=COMPONENT.model_name,
-    rated_bounds=COMPONENT.rated_bounds,
+    metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
 
@@ -208,7 +208,7 @@ DIFFERENT_BOTH_ID = _TestElectricalComponent(
     name=COMPONENT.name,
     manufacturer=COMPONENT.manufacturer,
     model_name=COMPONENT.model_name,
-    rated_bounds=COMPONENT.rated_bounds,
+    metric_config_bounds=COMPONENT.metric_config_bounds,
     category_specific_metadata=COMPONENT.category_specific_metadata,
 )
 

--- a/tests/microgrid/electrical_components/test_ev_charger.py
+++ b/tests/microgrid/electrical_components/test_ev_charger.py
@@ -51,8 +51,6 @@ def test_abstract_ev_charger_cannot_be_instantiated(
             id=component_id,
             microgrid_id=microgrid_id,
             name="test_charger",
-            manufacturer="test_manufacturer",
-            model_name="test_model",
             type=EvChargerType.AC,
         )
 
@@ -85,15 +83,11 @@ def test_recognized_ev_charger_types(  # Renamed from test_ev_charger_types
         id=component_id,
         microgrid_id=microgrid_id,
         name=case.name,
-        manufacturer="test_manufacturer",
-        model_name="test_model",
     )
 
     assert charger.id == component_id
     assert charger.microgrid_id == microgrid_id
     assert charger.name == case.name
-    assert charger.manufacturer == "test_manufacturer"
-    assert charger.model_name == "test_model"
     assert charger.category == ElectricalComponentCategory.EV_CHARGER
     assert charger.type == case.expected_type
 
@@ -106,15 +100,11 @@ def test_unrecognized_ev_charger_type(
         id=component_id,
         microgrid_id=microgrid_id,
         name="unrecognized_charger",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         type=999,  # type is passed here for UnrecognizedEvCharger
     )
 
     assert charger.id == component_id
     assert charger.microgrid_id == microgrid_id
     assert charger.name == "unrecognized_charger"
-    assert charger.manufacturer == "test_manufacturer"
-    assert charger.model_name == "test_model"
     assert charger.category == ElectricalComponentCategory.EV_CHARGER
     assert charger.type == 999

--- a/tests/microgrid/electrical_components/test_grid_connection_point.py
+++ b/tests/microgrid/electrical_components/test_grid_connection_point.py
@@ -36,16 +36,12 @@ def test_creation_ok(
         id=component_id,
         microgrid_id=microgrid_id,
         name="test_grid_point",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         rated_fuse_current=rated_fuse_current,
     )
 
     assert grid_point.id == component_id
     assert grid_point.microgrid_id == microgrid_id
     assert grid_point.name == "test_grid_point"
-    assert grid_point.manufacturer == "test_manufacturer"
-    assert grid_point.model_name == "test_model"
     assert grid_point.category == ElectricalComponentCategory.GRID_CONNECTION_POINT
     assert grid_point.rated_fuse_current == rated_fuse_current
 
@@ -61,7 +57,5 @@ def test_creation_invalid_rated_fuse_current(
             id=component_id,
             microgrid_id=microgrid_id,
             name="test_grid_point",
-            manufacturer="test_manufacturer",
-            model_name="test_model",
             rated_fuse_current=-1,
         )

--- a/tests/microgrid/electrical_components/test_inverter.py
+++ b/tests/microgrid/electrical_components/test_inverter.py
@@ -51,8 +51,6 @@ def test_abstract_inverter_cannot_be_instantiated(
             id=component_id,
             microgrid_id=microgrid_id,
             name="test_inverter",
-            manufacturer="test_manufacturer",
-            model_name="test_model",
             type=InverterType.BATTERY,
         )
 
@@ -85,15 +83,11 @@ def test_recognized_inverter_types(
         id=component_id,
         microgrid_id=microgrid_id,
         name=case.name,
-        manufacturer="test_manufacturer",
-        model_name="test_model",
     )
 
     assert inverter.id == component_id
     assert inverter.microgrid_id == microgrid_id
     assert inverter.name == case.name
-    assert inverter.manufacturer == "test_manufacturer"
-    assert inverter.model_name == "test_model"
     assert inverter.category == ElectricalComponentCategory.INVERTER
     assert inverter.type == case.expected_type
 
@@ -106,15 +100,11 @@ def test_unrecognized_inverter_type(
         id=component_id,
         microgrid_id=microgrid_id,
         name="unrecognized_inverter",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         type=999,  # type is passed here for UnrecognizedInverter
     )
 
     assert inverter.id == component_id
     assert inverter.microgrid_id == microgrid_id
     assert inverter.name == "unrecognized_inverter"
-    assert inverter.manufacturer == "test_manufacturer"
-    assert inverter.model_name == "test_model"
     assert inverter.category == ElectricalComponentCategory.INVERTER
     assert inverter.type == 999

--- a/tests/microgrid/electrical_components/test_power_transformer.py
+++ b/tests/microgrid/electrical_components/test_power_transformer.py
@@ -39,8 +39,6 @@ def test_creation_ok(
         id=component_id,
         microgrid_id=microgrid_id,
         name="test_power_transformer",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         primary_voltage=primary,
         secondary_voltage=secondary,
     )
@@ -48,8 +46,6 @@ def test_creation_ok(
     assert power_transformer.id == component_id
     assert power_transformer.microgrid_id == microgrid_id
     assert power_transformer.name == "test_power_transformer"
-    assert power_transformer.manufacturer == "test_manufacturer"
-    assert power_transformer.model_name == "test_model"
     assert power_transformer.category == ElectricalComponentCategory.POWER_TRANSFORMER
     assert power_transformer.primary_voltage == pytest.approx(primary)
     assert power_transformer.secondary_voltage == pytest.approx(secondary)

--- a/tests/microgrid/electrical_components/test_problematic.py
+++ b/tests/microgrid/electrical_components/test_problematic.py
@@ -39,8 +39,6 @@ def test_abstract_problematic_electrical_component_cannot_be_instantiated(
             id=component_id,
             microgrid_id=microgrid_id,
             name="test_problematic",
-            manufacturer="test_manufacturer",
-            model_name="test_model",
             category=ElectricalComponentCategory.UNSPECIFIED,
         )
 
@@ -53,15 +51,11 @@ def test_unspecified_component(
         id=component_id,
         microgrid_id=microgrid_id,
         name="unspecified_component",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
     )
 
     assert component.id == component_id
     assert component.microgrid_id == microgrid_id
     assert component.name == "unspecified_component"
-    assert component.manufacturer == "test_manufacturer"
-    assert component.model_name == "test_model"
     assert component.category == ElectricalComponentCategory.UNSPECIFIED
 
 
@@ -74,16 +68,12 @@ def test_mismatched_category_component_with_known_category(
         id=component_id,
         microgrid_id=microgrid_id,
         name="mismatched_battery",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         category=expected_category,
     )
 
     assert component.id == component_id
     assert component.microgrid_id == microgrid_id
     assert component.name == "mismatched_battery"
-    assert component.manufacturer == "test_manufacturer"
-    assert component.model_name == "test_model"
     assert component.category == expected_category
 
 
@@ -96,16 +86,12 @@ def test_mismatched_category_component_with_unrecognized_category(
         id=component_id,
         microgrid_id=microgrid_id,
         name="mismatched_unrecognized",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         category=expected_category,
     )
 
     assert component.id == component_id
     assert component.microgrid_id == microgrid_id
     assert component.name == "mismatched_unrecognized"
-    assert component.manufacturer == "test_manufacturer"
-    assert component.model_name == "test_model"
     assert component.category == expected_category
 
 
@@ -117,14 +103,10 @@ def test_unrecognized_component_type(
         id=component_id,
         microgrid_id=microgrid_id,
         name="unrecognized_component",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
         category=999,
     )
 
     assert component.id == component_id
     assert component.microgrid_id == microgrid_id
     assert component.name == "unrecognized_component"
-    assert component.manufacturer == "test_manufacturer"
-    assert component.model_name == "test_model"
     assert component.category == 999

--- a/tests/microgrid/electrical_components/test_simple_components.py
+++ b/tests/microgrid/electrical_components/test_simple_components.py
@@ -71,13 +71,9 @@ def test_init(
         id=component_id,
         microgrid_id=microgrid_id,
         name="test_component",
-        manufacturer="test_manufacturer",
-        model_name="test_model",
     )
 
     assert component.id == component_id
     assert component.microgrid_id == microgrid_id
     assert component.name == "test_component"
-    assert component.manufacturer == "test_manufacturer"
-    assert component.model_name == "test_model"
     assert component.category == expected_category


### PR DESCRIPTION
The protobuf have a few new and deprecated fields and one existing field had a name that doesn't match the protobuf name, which could lead to confusion.

Since this code is new, we completely remove the deprecated fields.

Part of #203.