### PR TITLE
Fix component type enums

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/_battery.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_battery.py
@@ -7,10 +7,6 @@ import dataclasses
 import enum
 from typing import Any, Literal, Self, TypeAlias
 
-from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
-    electrical_components_pb2,
-)
-
 from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
@@ -19,13 +15,13 @@ from ._electrical_component import ElectricalComponent
 class BatteryType(enum.Enum):
     """The known types of batteries."""
 
-    UNSPECIFIED = electrical_components_pb2.BATTERY_TYPE_UNSPECIFIED
+    UNSPECIFIED = 0
     """The battery type is unspecified."""
 
-    LI_ION = electrical_components_pb2.BATTERY_TYPE_LI_ION
+    LI_ION = 1
     """Lithium-ion (Li-ion) battery."""
 
-    NA_ION = electrical_components_pb2.BATTERY_TYPE_NA_ION
+    NA_ION = 2
     """Sodium-ion (Na-ion) battery."""
 
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_ev_charger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_ev_charger.py
@@ -7,10 +7,6 @@ import dataclasses
 import enum
 from typing import Any, Literal, Self, TypeAlias
 
-from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
-    electrical_components_pb2,
-)
-
 from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
@@ -19,16 +15,16 @@ from ._electrical_component import ElectricalComponent
 class EvChargerType(enum.Enum):
     """The known types of electric vehicle (EV) chargers."""
 
-    UNSPECIFIED = electrical_components_pb2.EV_CHARGER_TYPE_UNSPECIFIED
+    UNSPECIFIED = 0
     """The type of the EV charger is unspecified."""
 
-    AC = electrical_components_pb2.EV_CHARGER_TYPE_AC
+    AC = 1
     """The EV charging station supports AC charging only."""
 
-    DC = electrical_components_pb2.EV_CHARGER_TYPE_DC
+    DC = 2
     """The EV charging station supports DC charging only."""
 
-    HYBRID = electrical_components_pb2.EV_CHARGER_TYPE_HYBRID
+    HYBRID = 3
     """The EV charging station supports both AC and DC."""
 
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_inverter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_inverter.py
@@ -7,10 +7,6 @@ import dataclasses
 import enum
 from typing import Any, Literal, Self, TypeAlias
 
-from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
-    electrical_components_pb2,
-)
-
 from ._category import ElectricalComponentCategory
 from ._electrical_component import ElectricalComponent
 
@@ -19,16 +15,16 @@ from ._electrical_component import ElectricalComponent
 class InverterType(enum.Enum):
     """The known types of inverters."""
 
-    UNSPECIFIED = electrical_components_pb2.INVERTER_TYPE_UNSPECIFIED
+    UNSPECIFIED = 0
     """The type of the inverter is unspecified."""
 
-    BATTERY = electrical_components_pb2.INVERTER_TYPE_BATTERY
+    BATTERY = 1
     """The inverter is a battery inverter."""
 
-    PV = electrical_components_pb2.INVERTER_TYPE_PV
+    PV = 2
     """The inverter is a PV inverter."""
 
-    HYBRID = electrical_components_pb2.INVERTER_TYPE_HYBRID
+    HYBRID = 3
     """The inverter is a hybrid inverter."""
 
 

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
@@ -3,6 +3,7 @@
 
 """Conversion of electrical component enums from/to protobuf v1alpha8."""
 
+from ._battery import battery_type_from_proto, battery_type_to_proto
 from ._category import (
     electrical_component_category_from_proto,
     electrical_component_category_to_proto,
@@ -19,6 +20,8 @@ from ._electrical_component_connection import (
     electrical_component_connection_from_proto,
     electrical_component_connection_from_proto_with_issues,
 )
+from ._ev_charger import ev_charger_type_from_proto, ev_charger_type_to_proto
+from ._inverter import inverter_type_from_proto, inverter_type_to_proto
 from ._operational_mode import (
     electrical_component_operational_mode_from_proto,
     electrical_component_operational_mode_to_proto,
@@ -29,6 +32,8 @@ from ._state_code import (
 )
 
 __all__ = [
+    "battery_type_from_proto",
+    "battery_type_to_proto",
     "electrical_component_category_from_proto",
     "electrical_component_category_to_proto",
     "electrical_component_connection_from_proto",
@@ -41,4 +46,8 @@ __all__ = [
     "electrical_component_operational_mode_to_proto",
     "electrical_component_state_code_from_proto",
     "electrical_component_state_code_to_proto",
+    "ev_charger_type_from_proto",
+    "ev_charger_type_to_proto",
+    "inverter_type_from_proto",
+    "inverter_type_to_proto",
 ]

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_battery.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_battery.py
@@ -1,0 +1,40 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of battery types to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from .....proto import enum_from_proto
+from ... import BatteryType
+
+
+def battery_type_from_proto(
+    message: electrical_components_pb2.BatteryType.ValueType,
+) -> BatteryType | int:
+    """Convert a protobuf BatteryType enum value to an enum member.
+
+    Args:
+        message: A protobuf BatteryType enum value.
+
+    Returns:
+        The corresponding BatteryType enum member, or the raw `int` if the
+            protobuf value is not recognized.
+    """
+    return enum_from_proto(message, BatteryType)
+
+
+def battery_type_to_proto(
+    battery_type: BatteryType,
+) -> electrical_components_pb2.BatteryType.ValueType:
+    """Convert a BatteryType enum member to a protobuf enum value.
+
+    Args:
+        battery_type: A BatteryType enum member.
+
+    Returns:
+        The corresponding protobuf BatteryType enum value.
+    """
+    return electrical_components_pb2.BatteryType.ValueType(battery_type.value)

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_ev_charger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_ev_charger.py
@@ -1,0 +1,40 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of EV charger types to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from .....proto import enum_from_proto
+from ... import EvChargerType
+
+
+def ev_charger_type_from_proto(
+    message: electrical_components_pb2.EvChargerType.ValueType,
+) -> EvChargerType | int:
+    """Convert a protobuf EvChargerType enum value to an enum member.
+
+    Args:
+        message: A protobuf EvChargerType enum value.
+
+    Returns:
+        The corresponding EvChargerType enum member, or the raw `int` if the
+            protobuf value is not recognized.
+    """
+    return enum_from_proto(message, EvChargerType)
+
+
+def ev_charger_type_to_proto(
+    ev_charger_type: EvChargerType,
+) -> electrical_components_pb2.EvChargerType.ValueType:
+    """Convert an EvChargerType enum member to a protobuf enum value.
+
+    Args:
+        ev_charger_type: An EvChargerType enum member.
+
+    Returns:
+        The corresponding protobuf EvChargerType enum value.
+    """
+    return electrical_components_pb2.EvChargerType.ValueType(ev_charger_type.value)

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_inverter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_inverter.py
@@ -1,0 +1,40 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Conversion of inverter types to/from protobuf v1alpha8."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from .....proto import enum_from_proto
+from ... import InverterType
+
+
+def inverter_type_from_proto(
+    message: electrical_components_pb2.InverterType.ValueType,
+) -> InverterType | int:
+    """Convert a protobuf InverterType enum value to an enum member.
+
+    Args:
+        message: A protobuf InverterType enum value.
+
+    Returns:
+        The corresponding InverterType enum member, or the raw `int` if the
+            protobuf value is not recognized.
+    """
+    return enum_from_proto(message, InverterType)
+
+
+def inverter_type_to_proto(
+    inverter_type: InverterType,
+) -> electrical_components_pb2.InverterType.ValueType:
+    """Convert an InverterType enum member to a protobuf enum value.
+
+    Args:
+        inverter_type: An InverterType enum member.
+
+    Returns:
+        The corresponding protobuf InverterType enum value.
+    """
+    return electrical_components_pb2.InverterType.ValueType(inverter_type.value)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_battery.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_battery.py
@@ -1,0 +1,25 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for battery type to/from protobuf v1alpha8 conversion."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from frequenz.client.common.microgrid.electrical_components import BatteryType
+from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
+    battery_type_from_proto,
+    battery_type_to_proto,
+)
+from frequenz.client.common.test.enum_parity import EnumParityTest
+
+
+class TestBatteryTypeParity(EnumParityTest):
+    """Parity tests for the `BatteryType` enum."""
+
+    python_enum = BatteryType
+    proto_enum = electrical_components_pb2.BatteryType
+    name_prefix = "BATTERY_TYPE_"
+    from_proto = staticmethod(battery_type_from_proto)
+    to_proto = staticmethod(battery_type_to_proto)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_ev_charger.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_ev_charger.py
@@ -1,0 +1,25 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for EV charger type to/from protobuf v1alpha8 conversion."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from frequenz.client.common.microgrid.electrical_components import EvChargerType
+from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
+    ev_charger_type_from_proto,
+    ev_charger_type_to_proto,
+)
+from frequenz.client.common.test.enum_parity import EnumParityTest
+
+
+class TestEvChargerTypeParity(EnumParityTest):
+    """Parity tests for the `EvChargerType` enum."""
+
+    python_enum = EvChargerType
+    proto_enum = electrical_components_pb2.EvChargerType
+    name_prefix = "EV_CHARGER_TYPE_"
+    from_proto = staticmethod(ev_charger_type_from_proto)
+    to_proto = staticmethod(ev_charger_type_to_proto)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_inverter.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_inverter.py
@@ -1,0 +1,25 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for inverter type to/from protobuf v1alpha8 conversion."""
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+
+from frequenz.client.common.microgrid.electrical_components import InverterType
+from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
+    inverter_type_from_proto,
+    inverter_type_to_proto,
+)
+from frequenz.client.common.test.enum_parity import EnumParityTest
+
+
+class TestInverterTypeParity(EnumParityTest):
+    """Parity tests for the `InverterType` enum."""
+
+    python_enum = InverterType
+    proto_enum = electrical_components_pb2.InverterType
+    name_prefix = "INVERTER_TYPE_"
+    from_proto = staticmethod(inverter_type_from_proto)
+    to_proto = staticmethod(inverter_type_to_proto)


### PR DESCRIPTION
Use integer literals for component type enums and add proto converters and parity tests.

Part of #203.