### PR TITLE
Load `UNSPECIFIED` as `0` in `metric_config_bounds` keys

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 * Added a new `frequenz.client.common.microgrid.Microgrid` type, together with the `frequenz.client.common.microgrid.proto.v1alpha8.microgrid_from_proto` conversion function.
 * Added a new `frequenz.client.common.ClientCommonError` base exception and `UnspecifiedValueError` at the package root.
 * Added a new `frequenz.client.common.microgrid.electrical_components` package, featuring a `ElectricalComponent` class hierarchy and its families (battery, inverter, EV charger, etc.), and `ElectricalComponentConnection`, including `v1alpha8` proto conversion functions.
+* Added a new `frequenz.client.common.microgrid.Microgrid` type with a raising `is_active()` method, together with the `frequenz.client.common.microgrid.proto.v1alpha8.microgrid_from_proto` conversion function.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -75,8 +75,8 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     These bounds may be derived from the component configuration, manufacturer
     limits, or limits of other devices.
 
-    The keys never include `Metric.UNSPECIFIED`: such entries are dropped when
-    loading from protobuf. Metrics unknown to this client version may still appear
+    `Metric.UNSPECIFIED` entries are stored as the plain `int` key `0` when
+    loading from protobuf. Metrics unknown to this client version may also appear
     as plain `int` keys for forward-compatibility.
     """
 

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -588,10 +588,7 @@ def _metric_config_bounds_from_proto(
         metric = enum_from_proto(metric_bound.metric, Metric)
         match metric:
             case Metric.UNSPECIFIED:
-                major_issues.append(
-                    "metric_config_bounds has an UNSPECIFIED metric, dropping it"
-                )
-                continue
+                metric = metric.value
             case int():
                 minor_issues.append(
                     f"metric_config_bounds has an unrecognized metric {metric}"

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -185,8 +185,8 @@ def _metric_bound(
     )
 
 
-def test_metric_config_bounds_drops_unspecified() -> None:
-    """Test UNSPECIFIED keys drop on load while unknown-int and real metrics survive."""
+def test_metric_config_bounds_stores_unspecified_as_int() -> None:
+    """Test UNSPECIFIED metric bounds load as plain int key 0."""
     major_issues: list[str] = []
     minor_issues: list[str] = []
     message = [
@@ -199,10 +199,9 @@ def test_metric_config_bounds_drops_unspecified() -> None:
         message, major_issues=major_issues, minor_issues=minor_issues
     )
 
+    assert parsed[int(Metric.UNSPECIFIED.value)] == Bounds(lower=0.0, upper=1.0)
     assert Metric.UNSPECIFIED not in parsed
     assert parsed[_UNKNOWN_METRIC_INT] == Bounds(lower=2.0, upper=3.0)
     assert parsed[Metric.DC_VOLTAGE] == Bounds(lower=4.0, upper=5.0)
-    assert any(
-        "UNSPECIFIED" in issue and "drop" in issue.lower() for issue in major_issues
-    )
+    assert not major_issues
     assert any(str(_UNKNOWN_METRIC_INT) in issue for issue in minor_issues)


### PR DESCRIPTION
This is to be consistent with how other deprecated `UNSPECIFIED` values are stored internally.

Part of #223.
