### PR TITLE
Rename `*ValueError` to `*EnumValueError`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,8 +63,8 @@
 * Added new exceptions:
 
     * `frequenz.client.common.ClientCommonError` as a base exception for the package.
-    * `frequenz.client.common.UnspecifiedValueError` for unspecified values (raw `0` or the deprecated member).
-    * `frequenz.client.common.UnrecognizedValueError` for enum members not yet recognized by the library. Carries the raw integer value in its `value` attribute.
+    * `frequenz.client.common.UnspecifiedEnumValueError` for unspecified enum values (raw `0` or the deprecated member).
+    * `frequenz.client.common.UnrecognizedEnumValueError` for enum members not yet recognized by the library. Carries the raw integer value in its `value` attribute.
 
 * Added safe convenience getters that raise the new exceptions for unspecified or unrecognized values:
 

--- a/src/frequenz/client/common/__init__.py
+++ b/src/frequenz/client/common/__init__.py
@@ -5,12 +5,12 @@
 
 from ._exception import (
     ClientCommonError,
-    UnrecognizedValueError,
-    UnspecifiedValueError,
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
 )
 
 __all__ = [
     "ClientCommonError",
-    "UnrecognizedValueError",
-    "UnspecifiedValueError",
+    "UnrecognizedEnumValueError",
+    "UnspecifiedEnumValueError",
 ]

--- a/src/frequenz/client/common/_exception.py
+++ b/src/frequenz/client/common/_exception.py
@@ -8,12 +8,12 @@ class ClientCommonError(Exception):
     """Base class for all errors raised by frequenz-client-common."""
 
 
-class UnrecognizedValueError(ClientCommonError, ValueError):
-    """Raised when a semantic accessor sees an unrecognized protobuf value.
+class UnrecognizedEnumValueError(ClientCommonError, ValueError):
+    """Raised when a semantic accessor sees an unrecognized protobuf enum value.
 
     This happens when the server sets an enum value that this version of the
     client does not recognize, as opposed to an unspecified value (see
-    [`UnspecifiedValueError`][..UnspecifiedValueError]). The raw
+    [`UnspecifiedEnumValueError`][..UnspecifiedEnumValueError]). The raw
     unrecognized value is available as `value`.
 
     This is also a ``ValueError`` for convenience.
@@ -33,11 +33,11 @@ class UnrecognizedValueError(ClientCommonError, ValueError):
         )
 
 
-class UnspecifiedValueError(ClientCommonError, ValueError):
-    """Raised when a semantic accessor sees an unspecified protobuf value.
+class UnspecifiedEnumValueError(ClientCommonError, ValueError):
+    """Raised when a semantic accessor sees an unspecified protobuf enum value.
 
     For a value that is set but not recognized by this client, see
-    [`UnrecognizedValueError`][..UnrecognizedValueError].
+    [`UnrecognizedEnumValueError`][..UnrecognizedEnumValueError].
 
     This is also a [`ValueError`][] for convenience.
     """

--- a/src/frequenz/client/common/grid/_delivery_area.py
+++ b/src/frequenz/client/common/grid/_delivery_area.py
@@ -9,7 +9,7 @@ from typing import assert_never
 
 from frequenz.core.enum import Enum, deprecated_member, unique
 
-from .._exception import UnrecognizedValueError, UnspecifiedValueError
+from .._exception import UnrecognizedEnumValueError, UnspecifiedEnumValueError
 
 
 @unique
@@ -109,21 +109,23 @@ class DeliveryArea:
             The code type, when it is a known `EnergyMarketCodeType` member.
 
         Raises:
-            UnspecifiedValueError: If the code type is unspecified.
-            UnrecognizedValueError: If the code type is a value not recognized by
-                this version of the client. The raw value is available on the
-                exception's `value` attribute.
+            UnspecifiedEnumValueError: If the code type is unspecified.
+            UnrecognizedEnumValueError: If the code type is a value not
+                recognized by this version of the client. The raw value is
+                available on the exception's `value` attribute.
         """
         # Suppressing the deprecation warning can be removed when UNSPECIFIED is removed
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             match self.code_type:
                 case 0 | EnergyMarketCodeType.UNSPECIFIED:
-                    raise UnspecifiedValueError(f"code type of {self} is unspecified")
+                    raise UnspecifiedEnumValueError(
+                        f"code type of {self} is unspecified"
+                    )
                 case EnergyMarketCodeType() as code_type:
                     return code_type
                 case int() as code_type:
-                    raise UnrecognizedValueError(
+                    raise UnrecognizedEnumValueError(
                         code_type,
                         f"code type {code_type!r} of {self} is not a recognized "
                         "EnergyMarketCodeType",

--- a/src/frequenz/client/common/metrics/_sample.py
+++ b/src/frequenz/client/common/metrics/_sample.py
@@ -11,7 +11,7 @@ from typing import assert_never
 
 from frequenz.core.enum import Enum, deprecated_member, unique
 
-from .._exception import UnrecognizedValueError, UnspecifiedValueError
+from .._exception import UnrecognizedEnumValueError, UnspecifiedEnumValueError
 from ._bounds import Bounds
 from ._metric import Metric
 
@@ -147,21 +147,23 @@ class MetricConnection:
             The category when it is a known `MetricConnectionCategory` member.
 
         Raises:
-            UnspecifiedValueError: If the category is unspecified (the raw value
-                `0` or a member whose value is `0`).
-            UnrecognizedValueError: If the category is an `int` this client does
-                not recognize. The raw value is available on the error's `value`
-                attribute.
+            UnspecifiedEnumValueError: If the category is unspecified (the raw
+                value `0` or a member whose value is `0`).
+            UnrecognizedEnumValueError: If the category is an `int` this
+                client does not recognize. The raw value is available on the
+                error's `value` attribute.
         """
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             match self.category:
                 case 0 | MetricConnectionCategory.UNSPECIFIED:
-                    raise UnspecifiedValueError("connection category is unspecified")
+                    raise UnspecifiedEnumValueError(
+                        "connection category is unspecified"
+                    )
                 case MetricConnectionCategory():
                     return self.category
                 case int():
-                    raise UnrecognizedValueError(
+                    raise UnrecognizedEnumValueError(
                         self.category,
                         f"connection category {self.category!r} is not a recognized "
                         "MetricConnectionCategory",
@@ -293,21 +295,21 @@ class MetricSample:
             The metric when it is a known `Metric` member.
 
         Raises:
-            UnspecifiedValueError: If the metric is unspecified (the raw value
-                `0` or a member whose value is `0`).
-            UnrecognizedValueError: If the metric is an `int` this client does
-                not recognize. The raw value is available on the error's `value`
-                attribute.
+            UnspecifiedEnumValueError: If the metric is unspecified (the raw
+                value `0` or a member whose value is `0`).
+            UnrecognizedEnumValueError: If the metric is an `int` this client
+                does not recognize. The raw value is available on the error's
+                `value` attribute.
         """
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             match self.metric:
                 case 0 | Metric.UNSPECIFIED:
-                    raise UnspecifiedValueError("sampled metric is unspecified")
+                    raise UnspecifiedEnumValueError("sampled metric is unspecified")
                 case Metric():
                     return self.metric
                 case int():
-                    raise UnrecognizedValueError(
+                    raise UnrecognizedEnumValueError(
                         self.metric,
                         f"sampled metric {self.metric!r} is not a recognized Metric",
                     )

--- a/src/frequenz/client/common/microgrid/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/_microgrid.py
@@ -6,7 +6,7 @@
 import datetime
 from dataclasses import dataclass, field
 
-from .._exception import UnspecifiedValueError
+from .._exception import UnspecifiedEnumValueError
 from ..grid._delivery_area import DeliveryArea
 from ..types._location import Location
 from ._ids import EnterpriseId, MicrogridId
@@ -77,11 +77,11 @@ class Microgrid:  # pylint: disable=too-many-instance-attributes
             Whether the microgrid is active.
 
         Raises:
-            UnspecifiedValueError: If the status is unspecified, so whether the
-                microgrid is active is unknown.
+            UnspecifiedEnumValueError: If the status is unspecified, so whether
+                the microgrid is active is unknown.
         """
         if self._active is None:
-            raise UnspecifiedValueError(
+            raise UnspecifiedEnumValueError(
                 f"status of microgrid {self} is unspecified; active state is unknown"
             )
         return self._active

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, Self
 
-from ..._exception import UnspecifiedValueError
+from ..._exception import UnspecifiedEnumValueError
 from ...metrics import Bounds, Metric
 from ...types import Lifetime
 from .. import MicrogridId
@@ -109,11 +109,11 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
             Whether this electrical component provides telemetry data.
 
         Raises:
-            UnspecifiedValueError: If the operational mode is unspecified, so whether
-                telemetry is provided is unknown.
+            UnspecifiedEnumValueError: If the operational mode is unspecified,
+                so whether telemetry is provided is unknown.
         """
         if self._provides_telemetry is None:
-            raise UnspecifiedValueError(
+            raise UnspecifiedEnumValueError(
                 f"operational mode of {self} is unspecified; "
                 "telemetry availability is unknown"
             )
@@ -126,11 +126,11 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
             Whether this electrical component accepts control commands.
 
         Raises:
-            UnspecifiedValueError: If the operational mode is unspecified, so whether
-                control commands are accepted is unknown.
+            UnspecifiedEnumValueError: If the operational mode is unspecified,
+                so whether control commands are accepted is unknown.
         """
         if self._accepts_control is None:
-            raise UnspecifiedValueError(
+            raise UnspecifiedEnumValueError(
                 f"operational mode of {self} is unspecified; "
                 "control availability is unknown"
             )

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -13,7 +13,7 @@ from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
 )
 from google.protobuf.json_format import MessageToDict
 
-from ....._exception import UnrecognizedValueError
+from ....._exception import UnrecognizedEnumValueError
 from .....metrics import Bounds, Metric
 from .....metrics.proto.v1alpha8 import bounds_from_proto
 from .....proto import enum_from_proto
@@ -744,7 +744,7 @@ def electrical_component_class_from_proto(
     * `(<any other typeless category>, None)` → its concrete typeless class
       (`Breaker`, `Meter`, ... one per category).
     * `(<any known typeless category>, <non-None subtype>)` → raises
-      `UnrecognizedValueError`.
+      `UnrecognizedEnumValueError`.
     * `(<unknown category int>, <any subtype>)` → `UnrecognizedElectricalComponent`
       (subtype silently dropped).
 
@@ -771,7 +771,7 @@ def electrical_component_class_from_proto(
         The corresponding electrical component class.
 
     Raises:
-        UnrecognizedValueError: If `subtype` is not `None` for a known
+        UnrecognizedEnumValueError: If `subtype` is not `None` for a known
             typeless category — that combination has no representation in the
             protobuf wire format.
     """
@@ -787,7 +787,7 @@ def electrical_component_class_from_proto(
     typeless_class = _TYPELESS_CLASS_BY_PROTO_CATEGORY.get(category)
     if typeless_class is not None:
         if subtype is not None:
-            raise UnrecognizedValueError(int(subtype))
+            raise UnrecognizedEnumValueError(int(subtype))
         return typeless_class
 
     return UnrecognizedElectricalComponent

--- a/tests/grid/proto/v1alpha8/test_delivery_area.py
+++ b/tests/grid/proto/v1alpha8/test_delivery_area.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 import pytest
 from frequenz.api.common.v1alpha8.grid import delivery_area_pb2
 
-from frequenz.client.common import UnspecifiedValueError
+from frequenz.client.common import UnspecifiedEnumValueError
 from frequenz.client.common.grid import EnergyMarketCodeType
 from frequenz.client.common.grid.proto.v1alpha8 import (
     delivery_area_from_proto,
@@ -122,7 +122,7 @@ def test_from_proto(
 
 
 def test_get_code_type_from_proto_unspecified_raises() -> None:
-    """A proto-loaded unspecified code type raises UnspecifiedValueError."""
+    """A proto-loaded unspecified code type raises UnspecifiedEnumValueError."""
     proto = delivery_area_pb2.DeliveryArea(
         code="TEST",
         code_type=(
@@ -133,5 +133,5 @@ def test_get_code_type_from_proto_unspecified_raises() -> None:
         warnings.simplefilter("error", DeprecationWarning)
         area = delivery_area_from_proto(proto)
     assert area.code_type == 0
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         area.get_code_type()

--- a/tests/grid/test_delivery_area.py
+++ b/tests/grid/test_delivery_area.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 
 import pytest
 
-from frequenz.client.common import UnrecognizedValueError, UnspecifiedValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.grid import DeliveryArea, EnergyMarketCodeType
 
 
@@ -124,25 +127,25 @@ def test_get_code_type_returns_known_member(member: EnergyMarketCodeType) -> Non
 
 
 def test_get_code_type_raises_unspecified_for_int_zero() -> None:
-    """get_code_type() raises UnspecifiedValueError for a raw int 0 code type."""
+    """get_code_type() raises UnspecifiedEnumValueError for a raw int 0 code type."""
     area = DeliveryArea(code="TEST", code_type=0)
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         area.get_code_type()
 
 
 def test_get_code_type_raises_unspecified_for_value_zero_member() -> None:
-    """get_code_type() raises UnspecifiedValueError for the value-0 member."""
+    """get_code_type() raises UnspecifiedEnumValueError for the value-0 member."""
     with pytest.deprecated_call():
         area = DeliveryArea(code="TEST", code_type=EnergyMarketCodeType.UNSPECIFIED)
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        with pytest.raises(UnspecifiedValueError):
+        with pytest.raises(UnspecifiedEnumValueError):
             area.get_code_type()
 
 
 def test_get_code_type_raises_unrecognized_for_unknown_int() -> None:
-    """get_code_type() raises UnrecognizedValueError carrying the raw value."""
+    """get_code_type() raises UnrecognizedEnumValueError carrying the raw value."""
     area = DeliveryArea(code="TEST", code_type=999)
-    with pytest.raises(UnrecognizedValueError) as exc_info:
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
         area.get_code_type()
     assert exc_info.value.value == 999

--- a/tests/metrics/test_sample_metric_connection.py
+++ b/tests/metrics/test_sample_metric_connection.py
@@ -5,7 +5,10 @@
 
 import pytest
 
-from frequenz.client.common import UnrecognizedValueError, UnspecifiedValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.metrics import MetricConnection, MetricConnectionCategory
 
 
@@ -108,23 +111,23 @@ def test_get_category_returns_known_member() -> None:
 
 
 def test_get_category_unspecified_int_raises() -> None:
-    """get_category raises UnspecifiedValueError for the raw int 0."""
+    """get_category raises UnspecifiedEnumValueError for the raw int 0."""
     connection = MetricConnection(category=0)
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         connection.get_category()
 
 
 def test_get_category_unspecified_member_raises() -> None:
-    """get_category raises UnspecifiedValueError for the value-0 member."""
+    """get_category raises UnspecifiedEnumValueError for the value-0 member."""
     with pytest.deprecated_call():
         connection = MetricConnection(category=MetricConnectionCategory.UNSPECIFIED)
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         connection.get_category()
 
 
 def test_get_category_unrecognized_int_raises() -> None:
-    """get_category raises UnrecognizedValueError carrying the raw int value."""
+    """get_category raises UnrecognizedEnumValueError carrying the raw int value."""
     connection = MetricConnection(category=99999)
-    with pytest.raises(UnrecognizedValueError) as exc_info:
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
         connection.get_category()
     assert exc_info.value.value == 99999

--- a/tests/metrics/test_sample_metric_sample.py
+++ b/tests/metrics/test_sample_metric_sample.py
@@ -7,7 +7,10 @@ from datetime import datetime, timezone
 
 import pytest
 
-from frequenz.client.common import UnrecognizedValueError, UnspecifiedValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.metrics import (
     AggregatedMetricValue,
     AggregationMethod,
@@ -150,25 +153,25 @@ def test_get_metric_returns_known_member(now: datetime) -> None:
 
 
 def test_get_metric_unspecified_int_raises(now: datetime) -> None:
-    """get_metric raises UnspecifiedValueError for the raw int 0."""
+    """get_metric raises UnspecifiedEnumValueError for the raw int 0."""
     sample = MetricSample(sample_time=now, metric=0, value=None, bounds=[])
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         sample.get_metric()
 
 
 def test_get_metric_unspecified_member_raises(now: datetime) -> None:
-    """get_metric raises UnspecifiedValueError for the value-0 member."""
+    """get_metric raises UnspecifiedEnumValueError for the value-0 member."""
     with pytest.deprecated_call():
         sample = MetricSample(
             sample_time=now, metric=Metric.UNSPECIFIED, value=None, bounds=[]
         )
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         sample.get_metric()
 
 
 def test_get_metric_unrecognized_int_raises(now: datetime) -> None:
-    """get_metric raises UnrecognizedValueError carrying the raw int value."""
+    """get_metric raises UnrecognizedEnumValueError carrying the raw int value."""
     sample = MetricSample(sample_time=now, metric=99999, value=None, bounds=[])
-    with pytest.raises(UnrecognizedValueError) as exc_info:
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
         sample.get_metric()
     assert exc_info.value.value == 99999

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
@@ -10,7 +10,7 @@ from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2 as ec_pb2,
 )
 
-from frequenz.client.common import UnrecognizedValueError
+from frequenz.client.common import UnrecognizedEnumValueError
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.electrical_components import (
     AcEvCharger,
@@ -525,7 +525,7 @@ def test_class_from_proto_rejects_typeless_subtype() -> None:
     """Test known typeless categories reject spurious subtype values."""
     # Given: a known typeless category with an impossible subtype.
     # When: the protobuf values are converted to a component class.
-    with pytest.raises(UnrecognizedValueError) as exc_info:
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
         electrical_component_class_from_proto(
             ec_pb2.ELECTRICAL_COMPONENT_CATEGORY_METER,
             cast(_ProtoSubtype, 1),

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from frequenz.client.common import UnspecifiedValueError
+from frequenz.client.common import UnspecifiedEnumValueError
 from frequenz.client.common.metrics import Bounds, Metric
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.electrical_components import (
@@ -102,7 +102,7 @@ def test_accessors_return_values_when_set() -> None:
 
 
 def test_accessors_raise_when_unspecified() -> None:
-    """Test that accessors raise UnspecifiedValueError when the value is unknown."""
+    """Test that accessors raise UnspecifiedEnumValueError when the value is unknown."""
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
@@ -111,9 +111,9 @@ def test_accessors_raise_when_unspecified() -> None:
         _allow_construction=True,
     )
 
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         component.provides_telemetry()
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         component.accepts_control()
 
 

--- a/tests/microgrid/proto/v1alpha8/test_microgrid.py
+++ b/tests/microgrid/proto/v1alpha8/test_microgrid.py
@@ -11,7 +11,7 @@ import pytest
 from frequenz.api.common.v1alpha8.grid import delivery_area_pb2
 from frequenz.api.common.v1alpha8.microgrid import microgrid_pb2
 
-from frequenz.client.common import UnspecifiedValueError
+from frequenz.client.common import UnspecifiedEnumValueError
 from frequenz.client.common.grid import DeliveryArea, EnergyMarketCodeType
 from frequenz.client.common.microgrid import EnterpriseId, MicrogridId
 from frequenz.client.common.microgrid.proto.v1alpha8 import microgrid_from_proto
@@ -194,7 +194,7 @@ def test_from_proto(
     # Verify the active state mapping and the raising accessor.
     assert info._active == case.expected_active  # pylint: disable=protected-access
     if case.expected_active is None:
-        with pytest.raises(UnspecifiedValueError):
+        with pytest.raises(UnspecifiedEnumValueError):
             info.is_active()
     else:
         assert info.is_active() is case.expected_active

--- a/tests/microgrid/test_microgrid.py
+++ b/tests/microgrid/test_microgrid.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from frequenz.client.common import UnspecifiedValueError
+from frequenz.client.common import UnspecifiedEnumValueError
 from frequenz.client.common.grid import DeliveryArea, EnergyMarketCodeType
 from frequenz.client.common.microgrid import EnterpriseId, Microgrid, MicrogridId
 from frequenz.client.common.types import Location
@@ -105,7 +105,7 @@ def test_is_active_unspecified() -> None:
         _active=None,
         _allow_construction=True,
     )
-    with pytest.raises(UnspecifiedValueError):
+    with pytest.raises(UnspecifiedEnumValueError):
         info.is_active()
 
 

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -3,42 +3,42 @@
 import frequenz.client.common
 from frequenz.client.common import (
     ClientCommonError,
-    UnrecognizedValueError,
-    UnspecifiedValueError,
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
 )
 
 
 def test_exceptions_exported_and_related() -> None:
     """Given exception exports, then their hierarchy and string form are correct."""
-    assert issubclass(UnspecifiedValueError, ClientCommonError)
-    assert issubclass(UnspecifiedValueError, ValueError)
-    assert issubclass(UnrecognizedValueError, ClientCommonError)
-    assert issubclass(UnrecognizedValueError, ValueError)
+    assert issubclass(UnspecifiedEnumValueError, ClientCommonError)
+    assert issubclass(UnspecifiedEnumValueError, ValueError)
+    assert issubclass(UnrecognizedEnumValueError, ClientCommonError)
+    assert issubclass(UnrecognizedEnumValueError, ValueError)
     assert not issubclass(ClientCommonError, ValueError)
-    assert str(UnspecifiedValueError("msg")) == "msg"
+    assert str(UnspecifiedEnumValueError("msg")) == "msg"
 
 
 def test_all_is_sorted_and_exports_unrecognized() -> None:
     """Given the package exports, then __all__ includes the new error and stays sorted."""
-    assert "UnrecognizedValueError" in frequenz.client.common.__all__
+    assert "UnrecognizedEnumValueError" in frequenz.client.common.__all__
     assert list(frequenz.client.common.__all__) == sorted(
         frequenz.client.common.__all__
     )
 
 
-def test_unrecognized_value_error_carries_value() -> None:
+def test_unrecognized_enum_value_error_carries_value() -> None:
     """Given an unrecognized value, then it is stored and catchable as both base types."""
-    error = UnrecognizedValueError(999)
+    error = UnrecognizedEnumValueError(999)
     assert error.value == 999
     assert isinstance(error, ValueError)
     assert isinstance(error, ClientCommonError)
 
 
-def test_unrecognized_value_error_default_message() -> None:
+def test_unrecognized_enum_value_error_default_message() -> None:
     """Given no explicit message, then the default string contains the raw value."""
-    assert "7" in str(UnrecognizedValueError(7))
+    assert "7" in str(UnrecognizedEnumValueError(7))
 
 
-def test_unrecognized_value_error_custom_message() -> None:
+def test_unrecognized_enum_value_error_custom_message() -> None:
     """Given a custom message, then the string form is exactly that message."""
-    assert str(UnrecognizedValueError(7, "msg")) == "msg"
+    assert str(UnrecognizedEnumValueError(7, "msg")) == "msg"


### PR DESCRIPTION
Both custom exceptions raised by the semantic accessors are specifically about protobuf enum values: an UNSPECIFIED proto enum reaching a `get_*` accessor, or an integer the client does not recognize as a member of the wrapper enum. The current names suggest a generic value error and leave the enum-value origin implicit.

Rename `UnspecifiedValueError` to `UnspecifiedEnumValueError` and `UnrecognizedValueError` to `UnrecognizedEnumValueError`, putting that origin in the type name.

Part of #223.
