### PR TITLE
Fix inheritance for problematic electrical components

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/_battery.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_battery.py
@@ -7,6 +7,7 @@ import dataclasses
 from typing import Any, Self, TypeAlias
 
 from ._electrical_component import ElectricalComponent
+from ._problematic import ProblematicElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -22,7 +23,7 @@ class Battery(ElectricalComponent):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnspecifiedBattery(Battery):
+class UnspecifiedBattery(Battery, ProblematicElectricalComponent):
     """A battery of an unspecified type."""
 
 
@@ -37,7 +38,7 @@ class NaIonBattery(Battery):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnrecognizedBattery(Battery):
+class UnrecognizedBattery(Battery, ProblematicElectricalComponent):
     """A battery of an unrecognized type."""
 
     type: int

--- a/src/frequenz/client/common/microgrid/electrical_components/_ev_charger.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_ev_charger.py
@@ -7,6 +7,7 @@ import dataclasses
 from typing import Any, Self, TypeAlias
 
 from ._electrical_component import ElectricalComponent
+from ._problematic import ProblematicElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -22,7 +23,7 @@ class EvCharger(ElectricalComponent):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnspecifiedEvCharger(EvCharger):
+class UnspecifiedEvCharger(EvCharger, ProblematicElectricalComponent):
     """An EV charger of an unspecified type."""
 
 
@@ -42,7 +43,7 @@ class HybridEvCharger(EvCharger):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnrecognizedEvCharger(EvCharger):
+class UnrecognizedEvCharger(EvCharger, ProblematicElectricalComponent):
     """An EV charger of an unrecognized type."""
 
     type: int

--- a/src/frequenz/client/common/microgrid/electrical_components/_inverter.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_inverter.py
@@ -7,6 +7,7 @@ import dataclasses
 from typing import Any, Self, TypeAlias
 
 from ._electrical_component import ElectricalComponent
+from ._problematic import ProblematicElectricalComponent
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -22,7 +23,7 @@ class Inverter(ElectricalComponent):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnspecifiedInverter(Inverter):
+class UnspecifiedInverter(Inverter, ProblematicElectricalComponent):
     """An inverter of an unspecified type."""
 
 
@@ -42,7 +43,7 @@ class HybridInverter(Inverter):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class UnrecognizedInverter(Inverter):
+class UnrecognizedInverter(Inverter, ProblematicElectricalComponent):
     """An inverter of an unrecognized type."""
 
     type: int

--- a/tests/microgrid/electrical_components/test_battery.py
+++ b/tests/microgrid/electrical_components/test_battery.py
@@ -11,6 +11,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponentId,
     LiIonBattery,
     NaIonBattery,
+    ProblematicElectricalComponent,
     UnrecognizedBattery,
     UnspecifiedBattery,
 )
@@ -85,3 +86,55 @@ def test_unrecognized_battery_type(
     assert battery.microgrid_id == microgrid_id
     assert battery.name == "unrecognized_battery"
     assert battery.type == 999
+
+
+def test_unspecified_battery_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnspecifiedBattery` is a `ProblematicElectricalComponent`."""
+    battery = UnspecifiedBattery(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(battery, ProblematicElectricalComponent)
+    assert isinstance(battery, Battery)
+
+
+def test_unrecognized_battery_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnrecognizedBattery` is a `ProblematicElectricalComponent`."""
+    battery = UnrecognizedBattery(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        type=999,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(battery, ProblematicElectricalComponent)
+    assert isinstance(battery, Battery)
+
+
+@pytest.mark.parametrize("cls", [LiIonBattery, NaIonBattery])
+def test_recognized_battery_types_are_not_problematic(
+    cls: type[LiIonBattery | NaIonBattery],
+    component_id: ElectricalComponentId,
+    microgrid_id: MicrogridId,
+) -> None:
+    """Test that recognized battery types are NOT `ProblematicElectricalComponent`."""
+    battery = cls(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert not isinstance(battery, ProblematicElectricalComponent)
+    assert isinstance(battery, Battery)

--- a/tests/microgrid/electrical_components/test_ev_charger.py
+++ b/tests/microgrid/electrical_components/test_ev_charger.py
@@ -12,6 +12,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponentId,
     EvCharger,
     HybridEvCharger,
+    ProblematicElectricalComponent,
     UnrecognizedEvCharger,
     UnspecifiedEvCharger,
 )
@@ -86,3 +87,55 @@ def test_unrecognized_ev_charger_type(
     assert charger.microgrid_id == microgrid_id
     assert charger.name == "unrecognized_charger"
     assert charger.type == 999
+
+
+def test_unspecified_ev_charger_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnspecifiedEvCharger` is a `ProblematicElectricalComponent`."""
+    charger = UnspecifiedEvCharger(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(charger, ProblematicElectricalComponent)
+    assert isinstance(charger, EvCharger)
+
+
+def test_unrecognized_ev_charger_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnrecognizedEvCharger` is a `ProblematicElectricalComponent`."""
+    charger = UnrecognizedEvCharger(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        type=999,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(charger, ProblematicElectricalComponent)
+    assert isinstance(charger, EvCharger)
+
+
+@pytest.mark.parametrize("cls", [AcEvCharger, DcEvCharger, HybridEvCharger])
+def test_recognized_ev_charger_types_are_not_problematic(
+    cls: type[AcEvCharger | DcEvCharger | HybridEvCharger],
+    component_id: ElectricalComponentId,
+    microgrid_id: MicrogridId,
+) -> None:
+    """Test that recognized EV charger types are NOT `ProblematicElectricalComponent`."""
+    charger = cls(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert not isinstance(charger, ProblematicElectricalComponent)
+    assert isinstance(charger, EvCharger)

--- a/tests/microgrid/electrical_components/test_inverter.py
+++ b/tests/microgrid/electrical_components/test_inverter.py
@@ -11,6 +11,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponentId,
     HybridInverter,
     Inverter,
+    ProblematicElectricalComponent,
     PvInverter,
     UnrecognizedInverter,
     UnspecifiedInverter,
@@ -86,3 +87,55 @@ def test_unrecognized_inverter_type(
     assert inverter.microgrid_id == microgrid_id
     assert inverter.name == "unrecognized_inverter"
     assert inverter.type == 999
+
+
+def test_unspecified_inverter_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnspecifiedInverter` is a `ProblematicElectricalComponent`."""
+    inverter = UnspecifiedInverter(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(inverter, ProblematicElectricalComponent)
+    assert isinstance(inverter, Inverter)
+
+
+def test_unrecognized_inverter_is_problematic(
+    component_id: ElectricalComponentId, microgrid_id: MicrogridId
+) -> None:
+    """Test that `UnrecognizedInverter` is a `ProblematicElectricalComponent`."""
+    inverter = UnrecognizedInverter(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        type=999,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert isinstance(inverter, ProblematicElectricalComponent)
+    assert isinstance(inverter, Inverter)
+
+
+@pytest.mark.parametrize("cls", [BatteryInverter, PvInverter, HybridInverter])
+def test_recognized_inverter_types_are_not_problematic(
+    cls: type[BatteryInverter | PvInverter | HybridInverter],
+    component_id: ElectricalComponentId,
+    microgrid_id: MicrogridId,
+) -> None:
+    """Test that recognized inverter types are NOT `ProblematicElectricalComponent`."""
+    inverter = cls(
+        id=component_id,
+        microgrid_id=microgrid_id,
+        _provides_telemetry=True,
+        _accepts_control=True,
+        _allow_construction=True,
+    )
+
+    assert not isinstance(inverter, ProblematicElectricalComponent)
+    assert isinstance(inverter, Inverter)


### PR DESCRIPTION
Make problematic battery, EV charger and inverter classes inherit from `ProblematicElectricalComponent`.
