### PR TITLE
Raise `UnrecognizedEnumValueError` from boolean accessors

### DIFF
--- a/src/frequenz/client/common/microgrid/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/_microgrid.py
@@ -5,8 +5,9 @@
 
 import datetime
 from dataclasses import dataclass, field
+from typing import assert_never
 
-from .._exception import UnspecifiedEnumValueError
+from .._exception import UnrecognizedEnumValueError, UnspecifiedEnumValueError
 from ..grid._delivery_area import DeliveryArea
 from ..types._location import Location
 from ._ids import EnterpriseId, MicrogridId
@@ -48,8 +49,14 @@ class Microgrid:  # pylint: disable=too-many-instance-attributes
     create_time: datetime.datetime
     """The UTC timestamp indicating when the microgrid was initially created."""
 
-    _active: bool | None
-    """Whether the microgrid is active, or `None` if its status is unspecified."""
+    _active: bool | int
+    """Whether the microgrid is active.
+
+    This stores the low-level representation of the microgrid state. It holds a `bool`
+    for a known active/inactive status, the raw `int` `0` when the status is
+    unspecified, or any other raw `int` not yet known to this client. Users should use
+    [`Microgrid.is_active()`][.is_active] to obtain a clear boolean or a clear error.
+    """
 
     _allow_construction: bool = field(
         default=False, repr=False, compare=False, hash=False
@@ -77,14 +84,23 @@ class Microgrid:  # pylint: disable=too-many-instance-attributes
             Whether the microgrid is active.
 
         Raises:
-            UnspecifiedEnumValueError: If the status is unspecified, so whether
-                the microgrid is active is unknown.
+            UnspecifiedEnumValueError: If the status is unspecified.
+            UnrecognizedEnumValueError: If the status is not recognized. The raw
+                status value is available on the error's `value` attribute.
         """
-        if self._active is None:
-            raise UnspecifiedEnumValueError(
-                f"status of microgrid {self} is unspecified; active state is unknown"
-            )
-        return self._active
+        match self._active:
+            case bool() as active:
+                return active
+            case 0:
+                raise UnspecifiedEnumValueError(
+                    f"status of microgrid {self} is unspecified"
+                )
+            case int() as value:
+                raise UnrecognizedEnumValueError(
+                    value, f"unrecognized status of microgrid {self}: {value!r}"
+                )
+            case unknown:
+                assert_never(unknown)
 
     def __str__(self) -> str:
         """Return the ID of this microgrid as a string."""

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -6,9 +6,9 @@
 import dataclasses
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any, Self
+from typing import Any, Self, assert_never
 
-from ..._exception import UnspecifiedEnumValueError
+from ..._exception import UnrecognizedEnumValueError, UnspecifiedEnumValueError
 from ...metrics import Bounds, Metric
 from ...types import Lifetime
 from .. import MicrogridId
@@ -37,11 +37,26 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     operational_lifetime: Lifetime = dataclasses.field(default_factory=Lifetime)
     """The operational lifetime of this electrical component."""
 
-    _provides_telemetry: bool | None
-    """Whether this component provides telemetry data, or `None` if unspecified."""
+    _provides_telemetry: bool | int
+    """Whether this component provides telemetry data.
 
-    _accepts_control: bool | None
-    """Whether this component accepts control commands, or `None` if unspecified."""
+    This stores the low-level representation of the operational mode. It holds a bool
+    for the telemetry part for a known operational mode, the raw `int` `0` when the
+    operational mode is unspecified, or any other raw `int` not yet known to this
+    client. Users should use
+    [`ElectricalComponent.provides_telemetry()`][.provides_telemetry] to obtain a clear
+    boolean or a clear error.
+    """
+
+    _accepts_control: bool | int
+    """Whether this component accepts control commands.
+
+    This stores the low-level representation of the operational mode. It holds a bool
+    for a known operational mode, the raw `int` `0` when the operational mode is
+    unspecified, or any other raw `int` not yet known to this client. Users should use
+    [`ElectricalComponent.accepts_control()`][.accepts_control] to obtain a clear
+    boolean or a clear error.
+    """
 
     _allow_construction: bool = dataclasses.field(
         default=False, repr=False, compare=False, hash=False
@@ -109,15 +124,27 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
             Whether this electrical component provides telemetry data.
 
         Raises:
-            UnspecifiedEnumValueError: If the operational mode is unspecified,
-                so whether telemetry is provided is unknown.
+            UnspecifiedEnumValueError: If the operational mode is unspecified.
+            UnrecognizedEnumValueError: If the operational mode is not recognized.
+                The raw value is available on the error's `value` attribute.
         """
-        if self._provides_telemetry is None:
-            raise UnspecifiedEnumValueError(
-                f"operational mode of {self} is unspecified; "
-                "telemetry availability is unknown"
-            )
-        return self._provides_telemetry
+        match self._provides_telemetry:
+            case bool() as provides_telemetry:
+                return provides_telemetry
+            case 0:
+                raise UnspecifiedEnumValueError(
+                    f"operational mode of {self} is unspecified; "
+                    "telemetry availability is unknown"
+                )
+            case int() as value:
+                raise UnrecognizedEnumValueError(
+                    value,
+                    f"operational mode {value!r} of {self} is not a recognized "
+                    "ElectricalComponentOperationalMode; telemetry availability "
+                    "is unknown",
+                )
+            case unknown:
+                assert_never(unknown)
 
     def accepts_control(self) -> bool:
         """Check whether this electrical component accepts control commands.
@@ -126,15 +153,27 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
             Whether this electrical component accepts control commands.
 
         Raises:
-            UnspecifiedEnumValueError: If the operational mode is unspecified,
-                so whether control commands are accepted is unknown.
+            UnspecifiedEnumValueError: If the operational mode is unspecified.
+            UnrecognizedEnumValueError: If the operational mode is not recognized.
+                The raw value is available on the error's `value` attribute.
         """
-        if self._accepts_control is None:
-            raise UnspecifiedEnumValueError(
-                f"operational mode of {self} is unspecified; "
-                "control availability is unknown"
-            )
-        return self._accepts_control
+        match self._accepts_control:
+            case bool() as accepts_control:
+                return accepts_control
+            case 0:
+                raise UnspecifiedEnumValueError(
+                    f"operational mode of {self} is unspecified; "
+                    "control availability is unknown"
+                )
+            case int() as value:
+                raise UnrecognizedEnumValueError(
+                    value,
+                    f"operational mode {value!r} of {self} is not a recognized "
+                    "ElectricalComponentOperationalMode; control availability "
+                    "is unknown",
+                )
+            case unknown:
+                assert_never(unknown)
 
     def is_operational_at(self, timestamp: datetime) -> bool:
         """Check whether this electrical component is operational at a specific timestamp.

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -797,7 +797,7 @@ def electrical_component_class_from_proto(
 # Message converters (full protobuf message ↔ instance)
 # ============================================================================
 
-_BOOLS_BY_OPERATIONAL_MODE: dict[int, tuple[bool | None, bool | None]] = {
+_BOOLS_BY_OPERATIONAL_MODE: dict[int, tuple[bool, bool]] = {
     electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_INACTIVE: (
         False,
         False,
@@ -817,7 +817,7 @@ _BOOLS_BY_OPERATIONAL_MODE: dict[int, tuple[bool | None, bool | None]] = {
 }
 
 
-def _operational_mode_to_bools(value: int) -> tuple[bool | None, bool | None]:
+def _operational_mode_to_bools(value: int) -> tuple[bool, bool] | tuple[int, int]:
     """Map a protobuf operational mode to telemetry/control booleans.
 
     Args:
@@ -825,10 +825,14 @@ def _operational_mode_to_bools(value: int) -> tuple[bool | None, bool | None]:
             `ELECTRICAL_COMPONENT_OPERATIONAL_MODE_*` constant).
 
     Returns:
-        A `(provides_telemetry, accepts_control)` tuple, with both elements `None`
-            when the operational mode is unspecified or unrecognized.
+        A `(provides_telemetry, accepts_control)` tuple of `bool`s for known
+            operational modes, or `(value, value)` (the raw `int` `value`
+            duplicated) when the operational mode is unspecified (`0`) or
+            unrecognized. This forward-compatible representation lets the
+            higher-level accessors distinguish unspecified from unrecognized
+            values.
     """
-    return _BOOLS_BY_OPERATIONAL_MODE.get(value, (None, None))
+    return _BOOLS_BY_OPERATIONAL_MODE.get(value, (value, value))
 
 
 def electrical_component_from_proto(
@@ -892,10 +896,10 @@ class _ElectricalComponentBaseData(NamedTuple):
     category_specific_info: dict[str, Any]
     """The category-specific metadata extracted from the protobuf message."""
 
-    provides_telemetry: bool | None
+    provides_telemetry: bool | int
     """Whether the electrical component provides telemetry, or `None` if unknown."""
 
-    accepts_control: bool | None
+    accepts_control: bool | int
     """Whether the electrical component accepts control, or `None` if unknown."""
 
     category_mismatched: bool = False

--- a/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
@@ -24,7 +24,7 @@ _ACTIVE_BY_STATUS: dict[int, bool] = {
 }
 
 
-def _microgrid_status_to_active(value: int) -> bool | None:
+def _microgrid_status_to_active(value: int) -> bool | int:
     """Map a protobuf microgrid status to an active boolean.
 
     Args:
@@ -32,10 +32,12 @@ def _microgrid_status_to_active(value: int) -> bool | None:
             constant).
 
     Returns:
-        `True` if active, `False` if inactive, or `None` when the status is
-            unspecified or unrecognized.
+        `True` if active, `False` if inactive, or the raw `int` `value`
+            unchanged when the status is unspecified (`0`) or unrecognized.
+            This forward-compatible representation lets the higher-level
+            accessor distinguish unspecified from unrecognized values.
     """
-    return _ACTIVE_BY_STATUS.get(value)
+    return _ACTIVE_BY_STATUS.get(value, value)
 
 
 def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
@@ -69,7 +71,7 @@ def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
     active = _microgrid_status_to_active(message.status)
     if message.status == microgrid_pb2.MICROGRID_STATUS_UNSPECIFIED:
         major_issues.append("status is unspecified")
-    elif active is None:
+    elif not isinstance(active, bool):
         major_issues.append("status is unrecognized")
 
     if major_issues:

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -86,12 +86,9 @@ def assert_base_data(
 
 
 _OPERATIONAL_MODE_BY_BOOLS: dict[
-    tuple[bool | None, bool | None],
+    tuple[bool, bool],
     electrical_components_pb2.ElectricalComponentOperationalMode.ValueType,
 ] = {
-    (None, None): (
-        electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_UNSPECIFIED
-    ),
     (False, False): (
         electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_INACTIVE
     ),
@@ -110,7 +107,23 @@ _OPERATIONAL_MODE_BY_BOOLS: dict[
 def base_data_as_proto(
     base_data: _ElectricalComponentBaseData,
 ) -> electrical_components_pb2.ElectricalComponent:
-    """Convert this _ElectricalComponentBaseData to a protobuf ElectricalComponent."""
+    """Convert this _ElectricalComponentBaseData to a protobuf ElectricalComponent.
+
+    Note: only base data with recognized `bool` values for both
+    `provides_telemetry` and `accepts_control` can be round-tripped through
+    this helper. Tests that need to exercise the unspecified or unrecognized
+    cases must build the protobuf message directly.
+    """
+    provides_telemetry = base_data.provides_telemetry
+    accepts_control = base_data.accepts_control
+    assert isinstance(provides_telemetry, bool), (
+        "base_data_as_proto only supports bool provides_telemetry; "
+        f"got {provides_telemetry!r}"
+    )
+    assert isinstance(accepts_control, bool), (
+        "base_data_as_proto only supports bool accepts_control; "
+        f"got {accepts_control!r}"
+    )
     proto = electrical_components_pb2.ElectricalComponent(
         id=int(base_data.component_id),
         microgrid_id=int(base_data.microgrid_id),
@@ -122,7 +135,7 @@ def base_data_as_proto(
             else int(base_data.category.value)
         ),
         operational_mode=_OPERATIONAL_MODE_BY_BOOLS[
-            (base_data.provides_telemetry, base_data.accepts_control)
+            (provides_telemetry, accepts_control)
         ],
     )
     if base_data.lifetime:

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -30,7 +30,7 @@ from .conftest import base_data_as_proto
     [
         (
             electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_UNSPECIFIED,
-            (None, None),
+            (0, 0),
         ),
         (
             electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_INACTIVE,
@@ -48,7 +48,7 @@ from .conftest import base_data_as_proto
             electrical_components_pb2.ELECTRICAL_COMPONENT_OPERATIONAL_MODE_CONTROL_AND_TELEMETRY,
             (True, True),
         ),
-        (999, (None, None)),
+        (999, (999, 999)),
     ],
     ids=[
         "unspecified",
@@ -60,10 +60,16 @@ from .conftest import base_data_as_proto
     ],
 )
 def test_operational_mode_to_bools(
-    proto_value: int, expected: tuple[bool | None, bool | None]
+    proto_value: int, expected: tuple[bool | int, bool | int]
 ) -> None:
     """Test that proto operational-mode values map to (provides_telemetry, accepts_control)."""
-    assert _operational_mode_to_bools(proto_value) == expected
+    result = _operational_mode_to_bools(proto_value)
+    assert result == expected
+    # The raw int representation must be preserved as `int` (not `bool`) so the
+    # higher-level accessor can distinguish unspecified (0) from unrecognized
+    # values and from recognized False (which compares equal to 0).
+    assert type(result[0]) is type(expected[0])
+    assert type(result[1]) is type(expected[1])
 
 
 def test_complete(default_component_base_data: _ElectricalComponentBaseData) -> None:

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from frequenz.client.common import UnspecifiedEnumValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.metrics import Bounds, Metric
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.electrical_components import (
@@ -102,12 +105,12 @@ def test_accessors_return_values_when_set() -> None:
 
 
 def test_accessors_raise_when_unspecified() -> None:
-    """Test that accessors raise UnspecifiedEnumValueError when the value is unknown."""
+    """Test that accessors raise UnspecifiedEnumValueError for the raw int `0`."""
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
-        _provides_telemetry=None,
-        _accepts_control=None,
+        _provides_telemetry=0,
+        _accepts_control=0,
         _allow_construction=True,
     )
 
@@ -115,6 +118,24 @@ def test_accessors_raise_when_unspecified() -> None:
         component.provides_telemetry()
     with pytest.raises(UnspecifiedEnumValueError):
         component.accepts_control()
+
+
+def test_accessors_raise_when_unrecognized() -> None:
+    """Test that accessors raise UnrecognizedEnumValueError for an unknown int."""
+    component = _TestElectricalComponent(
+        id=ElectricalComponentId(1),
+        microgrid_id=MicrogridId(2),
+        _provides_telemetry=999,
+        _accepts_control=999,
+        _allow_construction=True,
+    )
+
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
+        component.provides_telemetry()
+    assert exc_info.value.value == 999
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
+        component.accepts_control()
+    assert exc_info.value.value == 999
 
 
 @pytest.mark.parametrize(

--- a/tests/microgrid/proto/v1alpha8/test_microgrid.py
+++ b/tests/microgrid/proto/v1alpha8/test_microgrid.py
@@ -11,9 +11,12 @@ import pytest
 from frequenz.api.common.v1alpha8.grid import delivery_area_pb2
 from frequenz.api.common.v1alpha8.microgrid import microgrid_pb2
 
-from frequenz.client.common import UnspecifiedEnumValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.grid import DeliveryArea, EnergyMarketCodeType
-from frequenz.client.common.microgrid import EnterpriseId, MicrogridId
+from frequenz.client.common.microgrid import EnterpriseId, Microgrid, MicrogridId
 from frequenz.client.common.microgrid.proto.v1alpha8 import microgrid_from_proto
 from frequenz.client.common.types import Location
 
@@ -37,11 +40,32 @@ class _ProtoConversionTestCase:
     status: int
     """The raw protobuf `MICROGRID_STATUS_*` value to set in the message."""
 
-    expected_active: bool | None
-    """The expected `_active` value after conversion (`None` if unspecified/unknown)."""
+    expected_active: bool | int
+    """The expected `_active` value after conversion.
+
+    `True`/`False` for recognized statuses, the raw `int` `0` when the status
+    is unspecified, or any other raw `int` when the status is unrecognized.
+    """
 
     expected_log: tuple[str, str] | None = None
     """Whether to expect a log during conversion (level, message)."""
+
+
+def _assert_active(info: Microgrid, expected_active: bool | int) -> None:
+    """Assert that ``info._active`` matches ``expected_active`` and the accessor agrees."""
+    active = info._active  # pylint: disable=protected-access
+    assert active == expected_active
+    assert type(active) is type(expected_active)
+    match expected_active:
+        case bool() as expected_bool:
+            assert info.is_active() is expected_bool
+        case 0:
+            with pytest.raises(UnspecifiedEnumValueError):
+                info.is_active()
+        case int() as expected_int:
+            with pytest.raises(UnrecognizedEnumValueError) as exc_info:
+                info.is_active()
+            assert exc_info.value.value == expected_int
 
 
 @pytest.mark.parametrize(
@@ -99,7 +123,7 @@ class _ProtoConversionTestCase:
             has_location=True,
             has_name=True,
             status=microgrid_pb2.MICROGRID_STATUS_UNSPECIFIED,
-            expected_active=None,
+            expected_active=0,
             expected_log=(
                 "WARNING",
                 "Found issues in microgrid: status is unspecified",
@@ -111,7 +135,7 @@ class _ProtoConversionTestCase:
             has_location=True,
             has_name=True,
             status=999,  # Unknown status value
-            expected_active=None,
+            expected_active=999,
             expected_log=(
                 "WARNING",
                 "Found issues in microgrid: status is unrecognized",
@@ -191,13 +215,7 @@ def test_from_proto(
     else:
         assert info.name is None
 
-    # Verify the active state mapping and the raising accessor.
-    assert info._active == case.expected_active  # pylint: disable=protected-access
-    if case.expected_active is None:
-        with pytest.raises(UnspecifiedEnumValueError):
-            info.is_active()
-    else:
-        assert info.is_active() is case.expected_active
+    _assert_active(info, case.expected_active)
 
     # Verify mock calls
     mock_datetime_from_proto.assert_called_once_with(proto.create_timestamp)

--- a/tests/microgrid/test_microgrid.py
+++ b/tests/microgrid/test_microgrid.py
@@ -8,7 +8,10 @@ from datetime import datetime, timezone
 
 import pytest
 
-from frequenz.client.common import UnspecifiedEnumValueError
+from frequenz.client.common import (
+    UnrecognizedEnumValueError,
+    UnspecifiedEnumValueError,
+)
 from frequenz.client.common.grid import DeliveryArea, EnergyMarketCodeType
 from frequenz.client.common.microgrid import EnterpriseId, Microgrid, MicrogridId
 from frequenz.client.common.types import Location
@@ -93,7 +96,7 @@ def test_is_active(active: bool) -> None:
 
 
 def test_is_active_unspecified() -> None:
-    """Test that is_active raises when the active state is unspecified."""
+    """Test that is_active raises when the active state is unspecified (raw int 0)."""
     now = datetime.now(timezone.utc)
     info = Microgrid(
         id=MicrogridId(1234),
@@ -102,11 +105,29 @@ def test_is_active_unspecified() -> None:
         delivery_area=None,
         location=None,
         create_time=now,
-        _active=None,
+        _active=0,
         _allow_construction=True,
     )
     with pytest.raises(UnspecifiedEnumValueError):
         info.is_active()
+
+
+def test_is_active_unrecognized() -> None:
+    """Test that is_active raises when the active state is an unrecognized int."""
+    now = datetime.now(timezone.utc)
+    info = Microgrid(
+        id=MicrogridId(1234),
+        enterprise_id=EnterpriseId(5678),
+        name=None,
+        delivery_area=None,
+        location=None,
+        create_time=now,
+        _active=999,
+        _allow_construction=True,
+    )
+    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
+        info.is_active()
+    assert exc_info.value.value == 999
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The boolean accessors `Microgrid.is_active()`, `ElectricalComponent.provides_telemetry()`, and `accepts_control()` wrap the `MicrogridStatus` and `ElectricalComponentOperationalMode` proto enums into a clean `bool`.

So far they only raised `UnspecifiedEnumValueError`, conflating the `UNSPECIFIED` proto sentinel with any other unknown protobuf enum value the server might send.

That made forward-compatibility silent: a future server-side mode would either disappear or look identical to `UNSPECIFIED` at the call site.

Align them with other enum values accessors (`get_*()`): the underlying low-level fields now hold a `bool` for known states, the raw `int` `0` for `UNSPECIFIED`, and the raw `int` value unchanged for any unrecognized server-side value.
