### PR TITLE
Make `Microgrid`/`ElectricalComponent` `.name` non-optional

### DIFF
--- a/src/frequenz/client/common/microgrid/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/_microgrid.py
@@ -37,7 +37,7 @@ class Microgrid:  # pylint: disable=too-many-instance-attributes
     enterprise_id: EnterpriseId
     """The unique identifier linking this microgrid to its parent enterprise account."""
 
-    name: str | None
+    name: str
     """The name of the microgrid."""
 
     delivery_area: DeliveryArea | None

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -25,7 +25,7 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     microgrid_id: MicrogridId
     """The ID of the microgrid this electrical component belongs to."""
 
-    name: str | None = None
+    name: str
     """The name of this electrical component."""
 
     model: str | None = None

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -878,8 +878,8 @@ class _ElectricalComponentBaseData(NamedTuple):
     microgrid_id: MicrogridId
     """The unique identifier of the parent microgrid."""
 
-    name: str | None
-    """The optional human-readable name of the electrical component."""
+    name: str
+    """The human-readable name of the electrical component."""
 
     model: str | None
     """The optional model string of the electrical component."""
@@ -928,8 +928,8 @@ def _electrical_component_base_from_proto_with_issues(
         component_id = ElectricalComponentId(message.id)
         microgrid_id = MicrogridId(message.microgrid_id)
 
-        name = message.name or None
-        if name is None:
+        name = message.name
+        if not name:
             minor_issues.append("name is empty")
 
         model = message.model or None

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -928,10 +928,6 @@ def _electrical_component_base_from_proto_with_issues(
         component_id = ElectricalComponentId(message.id)
         microgrid_id = MicrogridId(message.microgrid_id)
 
-        name = message.name
-        if not name:
-            minor_issues.append("name is empty")
-
         model = message.model or None
         if model is None:
             minor_issues.append("model is empty")
@@ -979,7 +975,7 @@ def _electrical_component_base_from_proto_with_issues(
         return _ElectricalComponentBaseData(
             component_id,
             microgrid_id,
-            name,
+            message.name,
             model,
             category,
             lifetime,

--- a/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
@@ -92,7 +92,7 @@ def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
     return Microgrid(
         id=MicrogridId(message.id),
         enterprise_id=EnterpriseId(message.enterprise_id),
-        name=message.name or None,
+        name=message.name,
         delivery_area=delivery_area,
         location=location,
         create_time=datetime_from_proto(message.create_timestamp),

--- a/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
+++ b/src/frequenz/client/common/microgrid/proto/v1alpha8/_microgrid.py
@@ -50,7 +50,6 @@ def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
         The corresponding [`Microgrid`][....Microgrid] object.
     """
     major_issues: list[str] = []
-    minor_issues: list[str] = []
 
     delivery_area: DeliveryArea | None = None
     if message.HasField("delivery_area"):
@@ -64,10 +63,6 @@ def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
     else:
         major_issues.append("location is missing")
 
-    name = message.name or None
-    if name is None:
-        minor_issues.append("name is empty")
-
     active = _microgrid_status_to_active(message.status)
     if message.status == microgrid_pb2.MICROGRID_STATUS_UNSPECIFIED:
         major_issues.append("status is unspecified")
@@ -78,13 +73,6 @@ def microgrid_from_proto(message: microgrid_pb2.Microgrid) -> Microgrid:
         _logger.warning(
             "Found issues in microgrid: %s | Protobuf message:\n%s",
             ", ".join(major_issues),
-            message,
-        )
-
-    if minor_issues:
-        _logger.debug(
-            "Found minor issues in microgrid: %s | Protobuf message:\n%s",
-            ", ".join(minor_issues),
             message,
         )
 

--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -127,7 +127,7 @@ def base_data_as_proto(
     proto = electrical_components_pb2.ElectricalComponent(
         id=int(base_data.component_id),
         microgrid_id=int(base_data.microgrid_id),
-        name=base_data.name or "",
+        name=base_data.name,
         model=base_data.model or "",
         category=electrical_components_pb2.ElectricalComponentCategory.ValueType(
             base_data.category

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
@@ -180,6 +180,7 @@ _TO_PROTO_CASES: list[tuple[type[ElectricalComponent], int, int | None]] = [
 _BASE_KWARGS: dict[str, object] = {
     "id": ElectricalComponentId(1),
     "microgrid_id": MicrogridId(1),
+    "name": "",
     "_provides_telemetry": True,
     "_accepts_control": True,
     "_allow_construction": True,

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -96,7 +96,7 @@ def test_missing_category_specific_info(
     major_issues: list[str] = []
     minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
-        name=None,
+        name="",
         category=ElectricalComponentCategory.UNSPECIFIED,
         lifetime=Lifetime(),
         metric_config_bounds={},

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -113,7 +113,6 @@ def test_missing_category_specific_info(
     assert sorted(major_issues) == sorted(["category is unspecified"])
     assert sorted(minor_issues) == sorted(
         [
-            "name is empty",
             "missing operational lifetime, considering it always operational",
         ]
     )

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
@@ -61,6 +61,7 @@ def test_raw_type_preserved_for_unknown(
     component = UnrecognizedBattery(
         id=default_component_base_data.component_id,
         microgrid_id=default_component_base_data.microgrid_id,
+        name="",
         type=999,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -92,6 +93,7 @@ def test_unrecognized_type_shows_in_repr(
     component = UnrecognizedBattery(
         id=default_component_base_data.component_id,
         microgrid_id=default_component_base_data.microgrid_id,
+        name="",
         type=999,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -109,6 +111,7 @@ def test_type_participates_in_equality_and_hash(
         return UnrecognizedBattery(
             id=default_component_base_data.component_id,
             microgrid_id=default_component_base_data.microgrid_id,
+            name="",
             type=battery_type,
             _provides_telemetry=True,
             _accepts_control=True,

--- a/tests/microgrid/electrical_components/test_battery.py
+++ b/tests/microgrid/electrical_components/test_battery.py
@@ -95,6 +95,7 @@ def test_unspecified_battery_is_problematic(
     battery = UnspecifiedBattery(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,
@@ -111,6 +112,7 @@ def test_unrecognized_battery_is_problematic(
     battery = UnrecognizedBattery(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         type=999,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -131,6 +133,7 @@ def test_recognized_battery_types_are_not_problematic(
     battery = cls(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -33,6 +33,7 @@ def test_base_creation_fails() -> None:
         _ = ElectricalComponent(
             id=ElectricalComponentId(1),
             microgrid_id=MicrogridId(1),
+            name="",
             _provides_telemetry=True,
             _accepts_control=True,
         )
@@ -44,6 +45,7 @@ def test_direct_construction_without_flag_raises() -> None:
         _TestElectricalComponent(
             id=ElectricalComponentId(1),
             microgrid_id=MicrogridId(2),
+            name="",
             _provides_telemetry=True,
             _accepts_control=True,
         )
@@ -54,12 +56,13 @@ def test_creation_with_defaults() -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,
     )
 
-    assert component.name is None
+    assert component.name == ""
     assert component.model is None
     assert component.operational_lifetime == Lifetime()
     assert component.metric_config_bounds == {}
@@ -95,6 +98,7 @@ def test_accessors_return_values_when_set() -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
+        name="",
         _provides_telemetry=True,
         _accepts_control=False,
         _allow_construction=True,
@@ -109,6 +113,7 @@ def test_accessors_raise_when_unspecified() -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
+        name="",
         _provides_telemetry=0,
         _accepts_control=0,
         _allow_construction=True,
@@ -125,6 +130,7 @@ def test_accessors_raise_when_unrecognized() -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(2),
+        name="",
         _provides_telemetry=999,
         _accepts_control=999,
         _allow_construction=True,
@@ -141,12 +147,12 @@ def test_accessors_raise_when_unrecognized() -> None:
 @pytest.mark.parametrize(
     "name,expected_str",
     [
-        (None, "CID1<_TestElectricalComponent>"),
+        ("", "CID1<_TestElectricalComponent>"),
         ("test-component", "CID1<_TestElectricalComponent>:test-component"),
     ],
     ids=["no-name", "with-name"],
 )
-def test_str(name: str | None, expected_str: str) -> None:
+def test_str(name: str, expected_str: str) -> None:
     """Test string representation of an electrical component."""
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
@@ -170,6 +176,7 @@ def test_operational_at(is_operational: bool) -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(1),
+        name="",
         operational_lifetime=mock_lifetime,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -195,6 +202,7 @@ def test_is_operational_now(mock_datetime: Mock) -> None:
     component = _TestElectricalComponent(
         id=ElectricalComponentId(1),
         microgrid_id=MicrogridId(1),
+        name="",
         operational_lifetime=mock_lifetime,
         _provides_telemetry=True,
         _accepts_control=True,

--- a/tests/microgrid/electrical_components/test_ev_charger.py
+++ b/tests/microgrid/electrical_components/test_ev_charger.py
@@ -96,6 +96,7 @@ def test_unspecified_ev_charger_is_problematic(
     charger = UnspecifiedEvCharger(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,
@@ -112,6 +113,7 @@ def test_unrecognized_ev_charger_is_problematic(
     charger = UnrecognizedEvCharger(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         type=999,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -132,6 +134,7 @@ def test_recognized_ev_charger_types_are_not_problematic(
     charger = cls(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,

--- a/tests/microgrid/electrical_components/test_grid_connection_point.py
+++ b/tests/microgrid/electrical_components/test_grid_connection_point.py
@@ -73,6 +73,7 @@ def test_creation_without_flag_raises(
         GridConnectionPoint(
             id=component_id,
             microgrid_id=microgrid_id,
+            name="",
             rated_fuse_current=0,
             _provides_telemetry=True,
             _accepts_control=True,

--- a/tests/microgrid/electrical_components/test_inverter.py
+++ b/tests/microgrid/electrical_components/test_inverter.py
@@ -96,6 +96,7 @@ def test_unspecified_inverter_is_problematic(
     inverter = UnspecifiedInverter(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,
@@ -112,6 +113,7 @@ def test_unrecognized_inverter_is_problematic(
     inverter = UnrecognizedInverter(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         type=999,
         _provides_telemetry=True,
         _accepts_control=True,
@@ -132,6 +134,7 @@ def test_recognized_inverter_types_are_not_problematic(
     inverter = cls(
         id=component_id,
         microgrid_id=microgrid_id,
+        name="",
         _provides_telemetry=True,
         _accepts_control=True,
         _allow_construction=True,

--- a/tests/microgrid/proto/v1alpha8/test_microgrid.py
+++ b/tests/microgrid/proto/v1alpha8/test_microgrid.py
@@ -213,7 +213,7 @@ def test_from_proto(
     if case.has_name:
         assert info.name == "Test Grid"
     else:
-        assert info.name is None
+        assert info.name == ""
 
     _assert_active(info, case.expected_active)
 

--- a/tests/microgrid/proto/v1alpha8/test_microgrid.py
+++ b/tests/microgrid/proto/v1alpha8/test_microgrid.py
@@ -115,7 +115,6 @@ def _assert_active(info: Microgrid, expected_active: bool | int) -> None:
             has_name=False,
             status=microgrid_pb2.MICROGRID_STATUS_ACTIVE,
             expected_active=True,
-            expected_log=("DEBUG", "Found minor issues in microgrid: name is empty"),
         ),
         _ProtoConversionTestCase(
             name="unspecified_status",

--- a/tests/microgrid/test_microgrid.py
+++ b/tests/microgrid/test_microgrid.py
@@ -118,7 +118,7 @@ def test_is_active_unrecognized() -> None:
     info = Microgrid(
         id=MicrogridId(1234),
         enterprise_id=EnterpriseId(5678),
-        name=None,
+        name="",
         delivery_area=None,
         location=None,
         create_time=now,

--- a/tests/microgrid/test_microgrid.py
+++ b/tests/microgrid/test_microgrid.py
@@ -55,7 +55,7 @@ def test_creation_without_optionals() -> None:
     info = Microgrid(
         id=MicrogridId(1234),
         enterprise_id=EnterpriseId(5678),
-        name=None,
+        name="",
         delivery_area=None,
         location=None,
         create_time=now,
@@ -65,7 +65,7 @@ def test_creation_without_optionals() -> None:
 
     assert info.id == MicrogridId(1234)
     assert info.enterprise_id == EnterpriseId(5678)
-    assert info.name is None
+    assert info.name == ""
     assert info.delivery_area is None
     assert info.location is None
     assert info.create_time == now
@@ -85,7 +85,7 @@ def test_is_active(active: bool) -> None:
     info = Microgrid(
         id=MicrogridId(1234),
         enterprise_id=EnterpriseId(5678),
-        name=None,
+        name="",
         delivery_area=None,
         location=None,
         create_time=now,
@@ -101,7 +101,7 @@ def test_is_active_unspecified() -> None:
     info = Microgrid(
         id=MicrogridId(1234),
         enterprise_id=EnterpriseId(5678),
-        name=None,
+        name="",
         delivery_area=None,
         location=None,
         create_time=now,
@@ -134,11 +134,10 @@ def test_is_active_unrecognized() -> None:
     "name,expected_str",
     [
         pytest.param("Test Grid", "MID1234:Test Grid", id="with-name"),
-        pytest.param(None, "MID1234", id="none-name"),
         pytest.param("", "MID1234", id="empty-name"),
     ],
 )
-def test_str(name: str | None, expected_str: str) -> None:
+def test_str(name: str, expected_str: str) -> None:
     """Test string representation of Microgrid."""
     now = datetime.now(timezone.utc)
     info = Microgrid(
@@ -161,7 +160,7 @@ def test_direct_construction_raises() -> None:
         Microgrid(
             id=MicrogridId(1234),
             enterprise_id=EnterpriseId(5678),
-            name=None,
+            name="",
             delivery_area=None,
             location=None,
             create_time=now,
@@ -175,7 +174,7 @@ def test_replace_preserves_construction() -> None:
     info = Microgrid(
         id=MicrogridId(1234),
         enterprise_id=EnterpriseId(5678),
-        name=None,
+        name="",
         delivery_area=None,
         location=None,
         create_time=now,


### PR DESCRIPTION
Both `Microgrid.name` and `ElectricalComponent.name` were typed `str | None`, forcing consumers to distinguish between "no name" and an empty name — semantically identical states, since the underlying protobuf `name` fields default to `""` when unset.

Change both to `str` and represent the absence of a name as `""` (matching the protobuf default). As a consequence, the `name is empty` minor issue reported by `microgrid_from_proto` and `_electrical_component_base_from_proto_with_issues` is no longer meaningful — being unnamed is now valid rather than an issue worth flagging — so it is removed.

Part of #239.