### PR TITLE
Don't raise high-level exceptions in proto conversion function

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -13,7 +13,6 @@ from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
 )
 from google.protobuf.json_format import MessageToDict
 
-from ....._exception import UnrecognizedEnumValueError
 from .....metrics import Bounds, Metric
 from .....metrics.proto.v1alpha8 import bounds_from_proto
 from .....proto import enum_from_proto
@@ -744,7 +743,7 @@ def electrical_component_class_from_proto(
     * `(<any other typeless category>, None)` → its concrete typeless class
       (`Breaker`, `Meter`, ... one per category).
     * `(<any known typeless category>, <non-None subtype>)` → raises
-      `UnrecognizedEnumValueError`.
+      [`ValueError`][].
     * `(<unknown category int>, <any subtype>)` → `UnrecognizedElectricalComponent`
       (subtype silently dropped).
 
@@ -771,9 +770,8 @@ def electrical_component_class_from_proto(
         The corresponding electrical component class.
 
     Raises:
-        UnrecognizedEnumValueError: If `subtype` is not `None` for a known
-            typeless category — that combination has no representation in the
-            protobuf wire format.
+        ValueError: If `subtype` is not `None` for a known typeless category —
+            that combination has no representation in the protobuf wire format.
     """
     abstract_base = _ABSTRACT_CLASS_BY_TYPED_PROTO_CATEGORY.get(category)
     if abstract_base is not None:
@@ -787,7 +785,10 @@ def electrical_component_class_from_proto(
     typeless_class = _TYPELESS_CLASS_BY_PROTO_CATEGORY.get(category)
     if typeless_class is not None:
         if subtype is not None:
-            raise UnrecognizedEnumValueError(int(subtype))
+            raise ValueError(
+                f"protobuf subtype {int(subtype)!r} is not valid for typeless "
+                f"category {int(category)!r}"
+            )
         return typeless_class
 
     return UnrecognizedElectricalComponent

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_class.py
@@ -10,7 +10,6 @@ from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2 as ec_pb2,
 )
 
-from frequenz.client.common import UnrecognizedEnumValueError
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.electrical_components import (
     AcEvCharger,
@@ -526,14 +525,16 @@ def test_class_from_proto_rejects_typeless_subtype() -> None:
     """Test known typeless categories reject spurious subtype values."""
     # Given: a known typeless category with an impossible subtype.
     # When: the protobuf values are converted to a component class.
-    with pytest.raises(UnrecognizedEnumValueError) as exc_info:
+    with pytest.raises(
+        ValueError, match=r"subtype 1 is not valid for typeless"
+    ) as exc_info:
         electrical_component_class_from_proto(
             ec_pb2.ELECTRICAL_COMPONENT_CATEGORY_METER,
             cast(_ProtoSubtype, 1),
         )
 
-    # Then: the failing raw protobuf subtype is exposed on the typed error.
-    assert exc_info.value.value == 1
+    # Then: a plain ValueError is raised, not one of the typed wrapper exceptions.
+    assert exc_info.type is ValueError
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`UnrecognizedEnumValueError` should only be raised from high-level wrappers, not protobuf conversion functions. Replace it with a simple `ValueError`, in this case someone just called the function with the wrong arguments.
