### PR TITLE
Improve `Bounds` and `BoundsSet`

### DIFF
--- a/src/frequenz/client/common/metrics/_bounds.py
+++ b/src/frequenz/client/common/metrics/_bounds.py
@@ -283,7 +283,7 @@ def _sort_and_merge_bounds(bounds: Iterable[Bounds]) -> tuple[Bounds, ...]:
     return tuple(result)
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, init=False)
 class BoundsSet:
     """A normalized set of metric bounds for efficient membership testing.
 
@@ -309,7 +309,7 @@ class BoundsSet:
         from frequenz.client.common.metrics import Bounds, BoundsSet
 
         allowed = BoundsSet(
-            bounds=(
+            (
                 Bounds(lower=1.0, upper=5.0),
                 Bounds(lower=3.0, upper=10.0),
                 Bounds(lower=15.0, upper=20.0),
@@ -328,9 +328,15 @@ class BoundsSet:
     bounds: tuple[Bounds, ...] = ()
     """The normalized bounds: sorted by lower bound and pairwise non-overlapping."""
 
-    def __post_init__(self) -> None:
-        """Normalize the bounds by sorting and merging overlapping ones."""
-        object.__setattr__(self, "bounds", _sort_and_merge_bounds(self.bounds))
+    def __init__(self, bounds: Iterable[Bounds] = ()) -> None:
+        """Create a normalized bounds set from a collection of bounds.
+
+        Args:
+            bounds: The bounds to normalize. Any collection is accepted; the
+                stored bounds are sorted by lower bound, with overlapping or
+                touching bounds merged.
+        """
+        object.__setattr__(self, "bounds", _sort_and_merge_bounds(bounds))
 
     def __contains__(self, item: FloatInt | None) -> bool:
         """Check whether a value is within any bounds of this set.

--- a/src/frequenz/client/common/metrics/_bounds.py
+++ b/src/frequenz/client/common/metrics/_bounds.py
@@ -247,17 +247,17 @@ def _sort_and_merge_bounds(bounds: Iterable[Bounds]) -> tuple[Bounds, ...]:
         A tuple of sorted, pairwise non-overlapping bounds covering the same
             values as the input, or the empty tuple when the union is unbounded.
     """
-    all_bounds = list(bounds)
-    if not all_bounds:
-        return ()
-
     with_none_lower: list[Bounds] = []
     with_real_lower: list[tuple[FloatInt, Bounds]] = []
-    for bound in all_bounds:
+    for bound in bounds:
         if bound.lower is None:
             with_none_lower.append(bound)
         else:
             with_real_lower.append((bound.lower, bound))
+
+    if not with_none_lower and not with_real_lower:
+        return ()
+
     with_real_lower.sort(key=lambda pair: pair[0])
     ordered = [pair[1] for pair in with_real_lower]
 

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -100,6 +100,13 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
     loading from protobuf. Metrics unknown to this client version may also appear
     as plain `int` keys for forward-compatibility.
 
+    Warning:
+        A `Metric` and its numeric value are distinct keys: `Metric` is not an
+        `int` subclass, so a `Metric` argument only matches `Metric`-keyed
+        entries and an `int` argument only matches `int`-keyed entries. `int`
+        metrics should only be used to look up unrecognized metrics, including
+        the raw `0` used for an unspecified metric.
+
     Tip:
         Prefer [`get_metric_config_bounds()`][..get_metric_config_bounds]
         when a valid [`BoundsSet`][.....metrics.BoundsSet] is required.
@@ -221,6 +228,14 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
         [`BoundsSet`][frequenz.client.common.metrics.BoundsSet] by default. Pass
         `default` to return a different value for absent entries instead,
         mimicking [`dict.get()`][dict.get].
+
+        Warning:
+            A `Metric` and its numeric value are distinct keys: `Metric` is not
+            an `int` subclass, so a `Metric` argument only matches
+            `Metric`-keyed entries and an `int` argument only matches
+            `int`-keyed entries. `int` metrics should only be used to look up
+            unrecognized metrics, including the raw `0` used for an unspecified
+            metric.
 
         Example:
             To check if a `metric` has **valid** configured bounds, you can use:

--- a/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_electrical_component.py
@@ -204,15 +204,15 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
                 assert_never(unknown)
 
     @overload
-    def get_metric_config_bounds(self, metric: Metric) -> BoundsSet: ...
+    def get_metric_config_bounds(self, metric: Metric | int) -> BoundsSet: ...
 
     @overload
     def get_metric_config_bounds(
-        self, metric: Metric, *, default: DefaultT
+        self, metric: Metric | int, *, default: DefaultT
     ) -> BoundsSet | DefaultT: ...
 
     def get_metric_config_bounds(
-        self, metric: Metric, *, default: object = BoundsSet()
+        self, metric: Metric | int, *, default: object = BoundsSet()
     ) -> object:
         """Return the configured bounds for a metric as a valid `BoundsSet`.
 
@@ -237,7 +237,10 @@ class ElectricalComponent:  # pylint: disable=too-many-instance-attributes
             directly, but avoid the special handling of invalid bounds.
 
         Args:
-            metric: The metric whose bounds to retrieve.
+            metric: The metric whose bounds to retrieve. A raw `int` looks up
+                an entry stored under an unrecognized metric value, including
+                the raw `0` used for an unspecified metric; it is matched as
+                given, with no special handling.
             default: The value to return when no bounds are configured for
                 `metric`.
 

--- a/tests/metrics/_bounds/test_bounds_set.py
+++ b/tests/metrics/_bounds/test_bounds_set.py
@@ -29,6 +29,29 @@ def test_default_is_empty() -> None:
     assert BoundsSet() == BoundsSet(bounds=())
 
 
+def test_positional_collection_construction() -> None:
+    """`BoundsSet` accepts any positional collection of bounds."""
+    from_list = BoundsSet([Bounds(lower=1.0, upper=5.0)])
+    assert from_list.bounds == (Bounds(lower=1.0, upper=5.0),)
+    assert 3.0 in from_list
+    assert from_list == BoundsSet((Bounds(lower=1.0, upper=5.0),))
+    assert from_list == BoundsSet(bounds=(Bounds(lower=1.0, upper=5.0),))
+
+
+def test_iter_construction() -> None:
+    """An iterator is accepted and normalized."""
+    from_set = BoundsSet(
+        b for b in (Bounds(lower=1.0, upper=5.0), Bounds(lower=3.0, upper=10.0))
+    )
+    assert from_set.bounds == (Bounds(lower=1.0, upper=10.0),)
+
+
+def test_positional_empty_collection_is_unbounded() -> None:
+    """A positional empty collection is the empty (unbounded) set."""
+    assert BoundsSet([]) == BoundsSet()
+    assert not BoundsSet([]).bounds
+
+
 def test_single() -> None:
     """A single bound is kept as-is and is bounded."""
     single = BoundsSet(bounds=(Bounds(lower=1.0, upper=5.0),))

--- a/tests/microgrid/electrical_components/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/test_electrical_component_base.py
@@ -300,6 +300,44 @@ def test_get_metric_config_bounds_invalid_raises_despite_default() -> None:
         component.get_metric_config_bounds(Metric.AC_POWER_ACTIVE, default=None)
 
 
+def test_get_metric_config_bounds_int_key_returns_valid_bounds() -> None:
+    """`get_metric_config_bounds` accepts a raw `int` key and returns its `Bounds`."""
+    bounds = BoundsSet(bounds=(Bounds(lower=-10.0, upper=10.0),))
+    component = _make_component(metric_config_bounds={999: bounds})
+
+    result = component.get_metric_config_bounds(999)
+
+    assert result is bounds
+
+
+def test_get_metric_config_bounds_int_key_zero_returns_valid_bounds() -> None:
+    """`get_metric_config_bounds` treats the raw `int` `0` like any other key."""
+    bounds = BoundsSet(bounds=(Bounds(lower=-10.0, upper=10.0),))
+    component = _make_component(metric_config_bounds={0: bounds})
+
+    result = component.get_metric_config_bounds(0)
+
+    assert result is bounds
+
+
+def test_get_metric_config_bounds_int_key_absent_returns_default() -> None:
+    """`get_metric_config_bounds` returns `default` for an absent `int` key."""
+    component = _make_component(metric_config_bounds={})
+
+    assert component.get_metric_config_bounds(999, default=None) is None
+
+
+def test_get_metric_config_bounds_int_key_invalid_raises_error() -> None:
+    """`get_metric_config_bounds` raises `InvalidBoundsError` for a malformed `int` entry."""
+    invalid = InvalidBoundsSet(bounds=(InvalidBounds(lower=10.0, upper=-10.0),))
+    component = _make_component(metric_config_bounds={999: invalid})
+
+    with pytest.raises(InvalidBoundsSetError) as exc_info:
+        component.get_metric_config_bounds(999)
+
+    assert exc_info.value.bounds_set is invalid
+
+
 @pytest.mark.parametrize(
     "name,expected_str",
     [


### PR DESCRIPTION
Accept `Metric | int` in `get_metric_config_bounds()`, so bounds for yet unrecognized metrics can be retrieved without the complexity of querying the raw data.

For `BoundsSet`, accept any iterable and positional arguments to make the interface more flexible and convenient, and avoid wrapping all bounds in a list when not necessary for performance reasons.
