### PR TITLE
Remove/deprecate remainain instances of `_with_issues` functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -153,6 +153,8 @@
 
 * Added a new `frequenz.client.common.metrics.MetricSample.bounds_set` field, typed `BoundsSet | InvalidBoundsSet`, replacing the deprecated `bounds` list (see Upgrading). Malformed wire bounds are preserved as an `InvalidBoundsSet` instead of being dropped. Use `get_bounds_set()` to resolve it to a valid `BoundsSet` or a clear `InvalidBoundsSetError`.
 
+* Added `frequenz.client.common.metrics.proto.v1alpha8.metric_sample_from_proto` and `metric_connection_from_proto`, dataclass-level converters returning `MetricSample` and `MetricConnection` with validity encoded in the return type: an unspecified or unrecognized `metric` / `category` is kept as a raw `int` (`Metric | int` / `MetricConnectionCategory | int`) and malformed bounds as an `InvalidBoundsSet`, so callers inspect the returned object (or the `get_*()` accessors) rather than collecting issue strings via a side channel.
+
 * Added a new `frequenz.client.common.types.Location` type together with the `frequenz.client.common.types.proto.v1alpha8.location_from_proto` conversion function.
 
 * Added a new `frequenz.client.common.microgrid.Microgrid` type, together with the `frequenz.client.common.microgrid.proto.v1alpha8.microgrid_from_proto` conversion function.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,6 +60,10 @@
 
     Validity is now encoded in the return type of `bounds_from_proto2` (`Bounds | InvalidBounds`), so callers should inspect the returned type instead of collecting issue strings via a side channel. The old converter continues to work but emits a `DeprecationWarning`.
 
+* `frequenz.client.common.metrics.proto.v1alpha8.metric_sample_from_proto_with_issues` and `metric_connection_from_proto_with_issues` are now deprecated; use `metric_sample_from_proto` and `metric_connection_from_proto` instead.
+
+    The new converters (see New Features) encode an unspecified or unrecognized `metric` / `category` as a raw `int` (`Metric | int` / `MetricConnectionCategory | int`) and malformed bounds as an `InvalidBoundsSet` in the returned object, so callers inspect validity on the returned type instead of collecting issue strings via a side channel. The old converters continue to work but emit a `DeprecationWarning`.
+
 * `frequenz.client.common.metrics.Bounds.__str__` now renders as `[lower,upper]` (no space after the comma) to match the compact format used by `Lifetime` and to compose cleanly with the `<invalid:...>` marker on `InvalidBounds`.
 
 * Several `__str__` representations were standardized around the `<invalid:VALUE>` marker, so a `grep '<invalid:'` over logs finds every invariant violation regardless of which type produced it:

--- a/src/frequenz/client/common/metrics/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/metrics/proto/v1alpha8/__init__.py
@@ -16,7 +16,9 @@ from ._metric_connection_category import (
 )
 from ._sample import (
     aggregated_metric_sample_from_proto,
+    metric_connection_from_proto,
     metric_connection_from_proto_with_issues,
+    metric_sample_from_proto,
     metric_sample_from_proto_with_issues,
 )
 
@@ -28,8 +30,10 @@ __all__ = [
     "bounds_set_from_proto",
     "metric_connection_category_from_proto",
     "metric_connection_category_to_proto",
+    "metric_connection_from_proto",
     "metric_connection_from_proto_with_issues",
     "metric_from_proto",
+    "metric_sample_from_proto",
     "metric_sample_from_proto_with_issues",
     "metric_to_proto",
 ]

--- a/src/frequenz/client/common/metrics/proto/v1alpha8/_sample.py
+++ b/src/frequenz/client/common/metrics/proto/v1alpha8/_sample.py
@@ -3,7 +3,10 @@
 
 """Loading of MetricSample and AggregatedMetricValue objects from protobuf messages."""
 
+import warnings
+
 from frequenz.api.common.v1alpha8.metrics import metrics_pb2
+from typing_extensions import deprecated
 
 from ....proto import datetime_from_proto
 from ..._metric import Metric
@@ -113,6 +116,10 @@ def metric_sample_from_proto(
     )
 
 
+@deprecated(
+    "`metric_connection_from_proto_with_issues` is deprecated; use "
+    "`metric_connection_from_proto` and inspect the returned type instead."
+)
 def metric_connection_from_proto_with_issues(
     message: metrics_pb2.MetricConnection,
     *,
@@ -120,6 +127,13 @@ def metric_connection_from_proto_with_issues(
     minor_issues: list[str],
 ) -> MetricConnection:
     """Convert a protobuf message to a [`MetricConnection`][....MetricConnection] object.
+
+    Warning: Deprecated
+        Use [`metric_connection_from_proto`][..metric_connection_from_proto]
+        instead and inspect the returned type. The new converter encodes an
+        unspecified or unrecognized category in the returned
+        `MetricConnection.category` field (`MetricConnectionCategory | int`)
+        rather than routing it through a side-channel string list.
 
     Args:
         message: The protobuf message to convert.
@@ -145,6 +159,10 @@ def metric_connection_from_proto_with_issues(
     )
 
 
+@deprecated(
+    "`metric_sample_from_proto_with_issues` is deprecated; use "
+    "`metric_sample_from_proto` and inspect the returned type instead."
+)
 def metric_sample_from_proto_with_issues(
     message: metrics_pb2.MetricSample,
     *,
@@ -152,6 +170,13 @@ def metric_sample_from_proto_with_issues(
     minor_issues: list[str],
 ) -> MetricSample:
     """Convert a protobuf message to a [`MetricSample`][....MetricSample] object.
+
+    Warning: Deprecated
+        Use [`metric_sample_from_proto`][..metric_sample_from_proto] instead
+        and inspect the returned type. The new converter encodes an
+        unspecified or unrecognized `metric` (`Metric | int`) and malformed
+        bounds (`InvalidBoundsSet`) in the returned `MetricSample` rather than
+        routing them through a side-channel string list.
 
     Args:
         message: The protobuf message to convert.
@@ -182,9 +207,11 @@ def metric_sample_from_proto_with_issues(
 
     connection = None
     if message.HasField("connection"):
-        connection = metric_connection_from_proto_with_issues(
-            message.connection, major_issues=major_issues, minor_issues=minor_issues
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            connection = metric_connection_from_proto_with_issues(
+                message.connection, major_issues=major_issues, minor_issues=minor_issues
+            )
 
     return MetricSample(
         sample_time=sample_time,

--- a/src/frequenz/client/common/metrics/proto/v1alpha8/_sample.py
+++ b/src/frequenz/client/common/metrics/proto/v1alpha8/_sample.py
@@ -37,6 +37,82 @@ def aggregated_metric_sample_from_proto(
     )
 
 
+def metric_connection_from_proto(
+    message: metrics_pb2.MetricConnection,
+) -> MetricConnection:
+    """Convert a protobuf message to a [`MetricConnection`][....MetricConnection] object.
+
+    An unspecified category is preserved as the raw integer `0` and an
+    unrecognized one as its raw integer value in the `category` field (typed
+    `MetricConnectionCategory | int`), so malformed input is surfaced through
+    the returned type rather than a side channel.
+
+    Args:
+        message: The protobuf message to convert.
+
+    Returns:
+        The resulting [`MetricConnection`][....MetricConnection] object.
+    """
+    raw = message.category
+    category: MetricConnectionCategory | int = (
+        raw if raw == 0 else metric_connection_category_from_proto(raw)
+    )
+
+    return MetricConnection(
+        category=category,
+        name=message.name,
+    )
+
+
+def metric_sample_from_proto(
+    message: metrics_pb2.MetricSample,
+) -> MetricSample:
+    """Convert a protobuf message to a [`MetricSample`][....MetricSample] object.
+
+    Malformed or forward-incompatible input is surfaced through the returned
+    type rather than a side channel: an unspecified metric is preserved as the
+    raw integer `0` and an unrecognized one as its raw integer value in the
+    `metric` field (typed `Metric | int`), and malformed bounds as an
+    `InvalidBoundsSet` in `bounds_set`.
+
+    Args:
+        message: The protobuf message to convert.
+
+    Returns:
+        The resulting [`MetricSample`][....MetricSample] object.
+    """
+    sample_time = datetime_from_proto(message.sample_time)
+
+    raw_metric = message.metric
+    metric: Metric | int = (
+        raw_metric if raw_metric == 0 else metric_from_proto(raw_metric)
+    )
+
+    value: float | AggregatedMetricValue | None = None
+    if message.HasField("value"):
+        match message.value.WhichOneof("metric_value_variant"):
+            case "simple_metric":
+                value = message.value.simple_metric.value
+            case "aggregated_metric":
+                value = aggregated_metric_sample_from_proto(
+                    message.value.aggregated_metric
+                )
+
+    bounds_set = bounds_set_from_proto(message.bounds)
+
+    connection = None
+    if message.HasField("connection"):
+        connection = metric_connection_from_proto(message.connection)
+
+    return MetricSample(
+        sample_time=sample_time,
+        metric=metric,
+        value=value,
+        bounds_set=bounds_set,
+        connection=connection,
+    )
+
+
 def metric_connection_from_proto_with_issues(
     message: metrics_pb2.MetricConnection,
     *,

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
@@ -25,7 +25,6 @@ from ._electrical_component import (
 )
 from ._electrical_component_connection import (
     electrical_component_connection_from_proto,
-    electrical_component_connection_from_proto_with_issues,
 )
 from ._state_code import (
     electrical_component_state_code_from_proto,
@@ -44,7 +43,6 @@ __all__ = [
     "electrical_component_class_from_proto",
     "electrical_component_class_to_proto",
     "electrical_component_connection_from_proto",
-    "electrical_component_connection_from_proto_with_issues",
     "electrical_component_diagnostic_code_from_proto",
     "electrical_component_diagnostic_code_to_proto",
     "electrical_component_from_proto",

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/__init__.py
@@ -21,7 +21,6 @@ from ._electrical_component import (
     electrical_component_class_from_proto,
     electrical_component_class_to_proto,
     electrical_component_from_proto,
-    electrical_component_from_proto_with_issues,
 )
 from ._electrical_component_connection import (
     electrical_component_connection_from_proto,
@@ -46,7 +45,6 @@ __all__ = [
     "electrical_component_diagnostic_code_from_proto",
     "electrical_component_diagnostic_code_to_proto",
     "electrical_component_from_proto",
-    "electrical_component_from_proto_with_issues",
     "electrical_component_state_code_from_proto",
     "electrical_component_state_code_to_proto",
 ]

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -3,7 +3,6 @@
 
 """Conversion of electrical components to/from protobuf v1alpha8."""
 
-import logging
 import warnings
 from collections.abc import Mapping, Sequence
 from typing import Final, NamedTuple, TypeAlias, assert_never, overload
@@ -69,9 +68,6 @@ from ..._steam_boiler import SteamBoiler
 from ..._types import ElectricalComponentTypes
 from ..._uninterruptible_power_supply import UninterruptiblePowerSupply
 from ..._wind_turbine import WindTurbine
-
-_logger = logging.getLogger(__name__)
-
 
 # We disable `too-many-arguments` in the whole file because all `_from_proto` functions
 # are expected to take many arguments, and `too-many-lines` because this module bundles
@@ -838,40 +834,6 @@ def _operational_mode_to_bools(value: int) -> tuple[bool, bool] | tuple[int, int
     return _BOOLS_BY_OPERATIONAL_MODE.get(value, (value, value))
 
 
-def electrical_component_from_proto(
-    message: electrical_components_pb2.ElectricalComponent,
-) -> ElectricalComponentTypes:
-    """Convert a protobuf message to an electrical component instance.
-
-    Args:
-        message: The protobuf message.
-
-    Returns:
-        The resulting electrical component instance.
-    """
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
-
-    component = electrical_component_from_proto_with_issues(
-        message, major_issues=major_issues, minor_issues=minor_issues
-    )
-
-    if major_issues:
-        _logger.warning(
-            "Found issues in electrical component: %s | Protobuf message:\n%s",
-            ", ".join(major_issues),
-            message,
-        )
-    if minor_issues:
-        _logger.debug(
-            "Found minor issues in electrical component: %s | Protobuf message:\n%s",
-            ", ".join(minor_issues),
-            message,
-        )
-
-    return component
-
-
 class _ElectricalComponentBaseData(NamedTuple):
     """Base data for an electrical component, extracted from a protobuf message."""
 
@@ -965,18 +927,13 @@ def _leftover_info(
 
 
 # pylint: disable-next=too-many-locals
-def _electrical_component_base_from_proto_with_issues(
+def _electrical_component_base_from_proto(
     message: electrical_components_pb2.ElectricalComponent,
-    *,
-    major_issues: list[str],
-    minor_issues: list[str],  # pylint: disable=unused-argument
 ) -> _ElectricalComponentBaseData:
-    """Extract base data from a protobuf message and collect issues.
+    """Extract base data from a protobuf message.
 
     Args:
         message: The protobuf message.
-        major_issues: A list to append major issues to.
-        minor_issues: A list to append minor issues to.
 
     Returns:
         An `_ElectricalComponentBaseData` named tuple containing the extracted data.
@@ -997,10 +954,6 @@ def _electrical_component_base_from_proto_with_issues(
         )
 
         category = enum_from_proto(message.category, ElectricalComponentCategory)
-        if category is ElectricalComponentCategory.UNSPECIFIED:
-            major_issues.append("category is unspecified")
-        elif isinstance(category, int):
-            major_issues.append(f"category {category} is unrecognized")
 
         category_specific_info_kind = message.category_specific_info.WhichOneof("kind")
         category_specific_info: CategorySpecificInfo | None = None
@@ -1021,10 +974,6 @@ def _electrical_component_base_from_proto_with_issues(
             and isinstance(category, ElectricalComponentCategory)
             and category.name.lower() != category_specific_info_kind
         ):
-            major_issues.append(
-                f"category_specific_info.kind ({category_specific_info_kind}) does not "
-                f"match the category ({category.name.lower()})",
-            )
             category_mismatched = True
 
         return _ElectricalComponentBaseData(
@@ -1043,27 +992,28 @@ def _electrical_component_base_from_proto_with_issues(
 
 
 # pylint: disable-next=too-many-locals,too-many-branches,too-many-return-statements
-def electrical_component_from_proto_with_issues(
+def electrical_component_from_proto(
     message: electrical_components_pb2.ElectricalComponent,
-    *,
-    major_issues: list[str],
-    minor_issues: list[str],
 ) -> ElectricalComponentTypes:
-    """Convert a protobuf message to an electrical component and collect issues.
+    """Convert a protobuf message to an electrical component instance.
+
+    Malformed or forward-incompatible input is surfaced through the returned
+    type rather than a side channel: an unspecified category yields an
+    `UnspecifiedElectricalComponent`, an unrecognized one an
+    `UnrecognizedElectricalComponent`, a category that disagrees with its
+    carried info a `MismatchedCategoryElectricalComponent`, and an unspecified
+    or unrecognized battery, EV charger or inverter type the matching
+    `Unrecognized*` class (which preserves the raw wire `type`).
 
     Args:
         message: The protobuf message.
-        major_issues: A list to append major issues to.
-        minor_issues: A list to append minor issues to.
 
     Returns:
         The resulting electrical component instance.
     """
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        base_data = _electrical_component_base_from_proto_with_issues(
-            message, major_issues=major_issues, minor_issues=minor_issues
-        )
+        base_data = _electrical_component_base_from_proto(message)
 
         if base_data.category_mismatched:
             return MismatchedCategoryElectricalComponent(
@@ -1129,14 +1079,6 @@ def electrical_component_from_proto_with_issues(
                 battery_info = _leftover_info(base_data.category_specific_info, "type")
                 raw_battery_type = message.category_specific_info.battery.type
                 battery_class = _BATTERY_CLASS_BY_PROTO_TYPE.get(raw_battery_type)
-                if raw_battery_type == (
-                    electrical_components_pb2.BATTERY_TYPE_UNSPECIFIED
-                ):
-                    major_issues.append("battery type is unspecified")
-                elif battery_class is None:
-                    major_issues.append(
-                        f"battery type {raw_battery_type} is unrecognized"
-                    )
                 if battery_class is None:
                     return UnrecognizedBattery(
                         id=base_data.component_id,
@@ -1171,14 +1113,6 @@ def electrical_component_from_proto_with_issues(
                 ev_charger_class = _EV_CHARGER_CLASS_BY_PROTO_TYPE.get(
                     raw_ev_charger_type
                 )
-                if raw_ev_charger_type == (
-                    electrical_components_pb2.EV_CHARGER_TYPE_UNSPECIFIED
-                ):
-                    major_issues.append("ev_charger type is unspecified")
-                elif ev_charger_class is None:
-                    major_issues.append(
-                        f"ev_charger type {raw_ev_charger_type} is unrecognized"
-                    )
                 if ev_charger_class is None:
                     return UnrecognizedEvCharger(
                         id=base_data.component_id,
@@ -1230,14 +1164,6 @@ def electrical_component_from_proto_with_issues(
                 inverter_info = _leftover_info(base_data.category_specific_info, "type")
                 raw_inverter_type = message.category_specific_info.inverter.type
                 inverter_class = _INVERTER_CLASS_BY_PROTO_TYPE.get(raw_inverter_type)
-                if raw_inverter_type == (
-                    electrical_components_pb2.INVERTER_TYPE_UNSPECIFIED
-                ):
-                    major_issues.append("inverter type is unspecified")
-                elif inverter_class is None:
-                    major_issues.append(
-                        f"inverter type {raw_inverter_type} is unrecognized"
-                    )
                 if inverter_class is None:
                     return UnrecognizedInverter(
                         id=base_data.component_id,

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component_connection.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component_connection.py
@@ -3,8 +3,6 @@
 
 """Loading of ElectricalComponentConnection objects from protobuf messages."""
 
-import logging
-
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
 )
@@ -18,13 +16,15 @@ from ... import (
     SelfReferencingElectricalComponentConnection,
 )
 
-_logger = logging.getLogger(__name__)
-
 
 def electrical_component_connection_from_proto(
     message: electrical_components_pb2.ElectricalComponentConnection,
 ) -> ElectricalComponentConnectionTypes:
     """Create an electrical component connection from a protobuf message.
+
+    A self-referencing connection (same source and destination component) is
+    returned as a `SelfReferencingElectricalComponentConnection`, which surfaces
+    that malformed state at the type level.
 
     Args:
         message: The protobuf message to convert.
@@ -32,50 +32,6 @@ def electrical_component_connection_from_proto(
     Returns:
         One of the concrete connection types.
     """
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
-
-    connection = electrical_component_connection_from_proto_with_issues(
-        message, major_issues=major_issues, minor_issues=minor_issues
-    )
-
-    if major_issues:
-        _logger.warning(
-            "Found issues in electrical component connection: %s | Protobuf message:\n%s",
-            ", ".join(major_issues),
-            message,
-        )
-    if minor_issues:
-        _logger.debug(
-            "Found minor issues in electrical component connection: %s | Protobuf message:\n%s",
-            ", ".join(minor_issues),
-            message,
-        )
-
-    return connection
-
-
-def electrical_component_connection_from_proto_with_issues(
-    message: electrical_components_pb2.ElectricalComponentConnection,
-    *,
-    major_issues: list[str],
-    minor_issues: list[str],
-) -> ElectricalComponentConnectionTypes:
-    """Create an electrical component connection from a protobuf message, collecting issues.
-
-    This function is useful when you want to collect issues during the parsing
-    of multiple connections, rather than logging them immediately.
-
-    Args:
-        message: The protobuf message to parse.
-        major_issues: A list to collect major issues found during parsing.
-        minor_issues: A list to collect minor issues found during parsing.
-
-    Returns:
-        One of the concrete connection types.
-    """
-    del minor_issues
-
     source_component_id = ElectricalComponentId(message.source_electrical_component_id)
     destination_component_id = ElectricalComponentId(
         message.destination_electrical_component_id
@@ -83,10 +39,6 @@ def electrical_component_connection_from_proto_with_issues(
     lifetime = _get_operational_lifetime_from_proto(message)
 
     if source_component_id == destination_component_id:
-        major_issues.append(
-            "self-referencing connection: source and destination are the same "
-            f"({source_component_id})",
-        )
         return SelfReferencingElectricalComponentConnection(
             source_id=source_component_id,
             destination_id=destination_component_id,

--- a/tests/metrics/proto/v1alpha8/test_sample_metric_connection.py
+++ b/tests/metrics/proto/v1alpha8/test_sample_metric_connection.py
@@ -10,6 +10,7 @@ from frequenz.api.common.v1alpha8.metrics import metrics_pb2
 from frequenz.client.common.metrics import MetricConnectionCategory
 from frequenz.client.common.metrics.proto.v1alpha8 import (
     metric_connection_category_to_proto,
+    metric_connection_from_proto,
     metric_connection_from_proto_with_issues,
 )
 
@@ -98,3 +99,57 @@ def test_with_empty_name() -> None:
     assert not connection.name
     assert not major_issues
     assert not minor_issues
+
+
+def test_from_proto_unspecified_category() -> None:
+    """An unspecified category is stored as the raw int 0 without warning."""
+    proto = metrics_pb2.MetricConnection(
+        category=metrics_pb2.MetricConnectionCategory.METRIC_CONNECTION_CATEGORY_UNSPECIFIED,
+        name="some_connection",
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        connection = metric_connection_from_proto(proto)
+
+    assert connection.category == 0
+    assert connection.name == "some_connection"
+
+
+def test_from_proto_unrecognized_category() -> None:
+    """An unrecognized category is preserved as its raw int value."""
+    proto = metrics_pb2.MetricConnection(
+        category=9999,  # type: ignore[arg-type]
+        name="unknown_connection",
+    )
+
+    connection = metric_connection_from_proto(proto)
+
+    assert connection.category == 9999
+    assert connection.name == "unknown_connection"
+
+
+def test_from_proto_valid_category() -> None:
+    """A valid category is resolved to its member."""
+    proto = metrics_pb2.MetricConnection(
+        category=metric_connection_category_to_proto(MetricConnectionCategory.BATTERY),
+        name="dc_battery_0",
+    )
+
+    connection = metric_connection_from_proto(proto)
+
+    assert connection.category == MetricConnectionCategory.BATTERY
+    assert connection.name == "dc_battery_0"
+
+
+def test_from_proto_empty_name() -> None:
+    """An empty name is preserved."""
+    proto = metrics_pb2.MetricConnection(
+        category=metric_connection_category_to_proto(MetricConnectionCategory.PV),
+        name="",
+    )
+
+    connection = metric_connection_from_proto(proto)
+
+    assert connection.category == MetricConnectionCategory.PV
+    assert not connection.name

--- a/tests/metrics/proto/v1alpha8/test_sample_metric_connection.py
+++ b/tests/metrics/proto/v1alpha8/test_sample_metric_connection.py
@@ -5,6 +5,7 @@
 
 import warnings
 
+import pytest
 from frequenz.api.common.v1alpha8.metrics import metrics_pb2
 
 from frequenz.client.common.metrics import MetricConnectionCategory
@@ -16,10 +17,10 @@ from frequenz.client.common.metrics.proto.v1alpha8 import (
 
 
 def test_with_unspecified_category() -> None:
-    """Test conversion with unspecified category stores int 0 and reports it.
+    """Test the deprecated converter stores int 0 for an unspecified category.
 
-    The conversion must store the raw int ``0`` (not the deprecated member) and
-    must not emit any ``DeprecationWarning`` of its own.
+    The conversion stores the raw int ``0`` (not the deprecated member) and
+    reports the unspecified category as a major issue.
     """
     proto = metrics_pb2.MetricConnection(
         category=metrics_pb2.MetricConnectionCategory.METRIC_CONNECTION_CATEGORY_UNSPECIFIED,
@@ -29,8 +30,7 @@ def test_with_unspecified_category() -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+    with pytest.deprecated_call(match="metric_connection_from_proto"):
         connection = metric_connection_from_proto_with_issues(
             proto, major_issues=major_issues, minor_issues=minor_issues
         )
@@ -51,9 +51,10 @@ def test_with_unrecognized_category() -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    connection = metric_connection_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    with pytest.deprecated_call(match="metric_connection_from_proto"):
+        connection = metric_connection_from_proto_with_issues(
+            proto, major_issues=major_issues, minor_issues=minor_issues
+        )
 
     assert connection.category == 9999
     assert connection.name == "unknown_connection"
@@ -71,9 +72,10 @@ def test_with_valid_category() -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    connection = metric_connection_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    with pytest.deprecated_call(match="metric_connection_from_proto"):
+        connection = metric_connection_from_proto_with_issues(
+            proto, major_issues=major_issues, minor_issues=minor_issues
+        )
 
     assert connection.category == MetricConnectionCategory.BATTERY
     assert connection.name == "dc_battery_0"
@@ -91,9 +93,10 @@ def test_with_empty_name() -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    connection = metric_connection_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    with pytest.deprecated_call(match="metric_connection_from_proto"):
+        connection = metric_connection_from_proto_with_issues(
+            proto, major_issues=major_issues, minor_issues=minor_issues
+        )
 
     assert connection.category == MetricConnectionCategory.PV
     assert not connection.name

--- a/tests/metrics/proto/v1alpha8/test_sample_metric_sample.py
+++ b/tests/metrics/proto/v1alpha8/test_sample_metric_sample.py
@@ -206,11 +206,12 @@ def test_from_proto_with_issues(case: _TestCase) -> None:
     # We use a fixed timestamp in test cases, so this is fine.
     # If dynamic timestamps were used, we'd need to adjust here or in the fixture.
 
-    sample = metric_sample_from_proto_with_issues(
-        case.proto_message,
-        major_issues=major_issues,
-        minor_issues=minor_issues,
-    )
+    with pytest.deprecated_call(match="metric_sample_from_proto"):
+        sample = metric_sample_from_proto_with_issues(
+            case.proto_message,
+            major_issues=major_issues,
+            minor_issues=minor_issues,
+        )
 
     assert sample == case.expected_sample
     assert major_issues == case.expected_major_issues
@@ -218,10 +219,10 @@ def test_from_proto_with_issues(case: _TestCase) -> None:
 
 
 def test_with_unspecified_metric() -> None:
-    """Test an unspecified metric is stored as int 0 without warning.
+    """Test the deprecated converter stores an unspecified metric as int 0.
 
     The dataclass-level converter stores the raw int ``0`` for an unspecified
-    metric (never the deprecated member) and emits no ``DeprecationWarning``.
+    metric (never the deprecated member).
     """
     proto = metrics_pb2.MetricSample(
         sample_time=TIMESTAMP,
@@ -234,8 +235,7 @@ def test_with_unspecified_metric() -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+    with pytest.deprecated_call(match="metric_sample_from_proto"):
         sample = metric_sample_from_proto_with_issues(
             proto, major_issues=major_issues, minor_issues=minor_issues
         )
@@ -269,9 +269,10 @@ def test_with_nan_bounds(lower: float, upper: float) -> None:
     major_issues: list[str] = []
     minor_issues: list[str] = []
 
-    sample = metric_sample_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    with pytest.deprecated_call(match="metric_sample_from_proto"):
+        sample = metric_sample_from_proto_with_issues(
+            proto, major_issues=major_issues, minor_issues=minor_issues
+        )
 
     assert isinstance(sample.bounds_set, InvalidBoundsSet)
 

--- a/tests/metrics/proto/v1alpha8/test_sample_metric_sample.py
+++ b/tests/metrics/proto/v1alpha8/test_sample_metric_sample.py
@@ -26,6 +26,7 @@ from frequenz.client.common.metrics import (
 )
 from frequenz.client.common.metrics.proto.v1alpha8 import (
     metric_connection_category_to_proto,
+    metric_sample_from_proto,
     metric_sample_from_proto_with_issues,
     metric_to_proto,
 )
@@ -273,3 +274,106 @@ def test_with_nan_bounds(lower: float, upper: float) -> None:
     )
 
     assert isinstance(sample.bounds_set, InvalidBoundsSet)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        _TestCase(
+            name="simple_value",
+            proto_message=metrics_pb2.MetricSample(
+                sample_time=TIMESTAMP,
+                metric=metric_to_proto(Metric.AC_POWER_ACTIVE),
+                value=metrics_pb2.MetricValueVariant(
+                    simple_metric=metrics_pb2.SimpleMetricValue(value=5.0)
+                ),
+            ),
+            expected_sample=MetricSample(
+                sample_time=DATETIME,
+                metric=Metric.AC_POWER_ACTIVE,
+                value=5.0,
+                bounds_set=BoundsSet(),
+                connection=None,
+            ),
+        ),
+        _TestCase(
+            name="unrecognized_metric",
+            proto_message=metrics_pb2.MetricSample(
+                sample_time=TIMESTAMP,
+                metric=999,  # type: ignore[arg-type]
+                value=metrics_pb2.MetricValueVariant(
+                    simple_metric=metrics_pb2.SimpleMetricValue(value=5.0)
+                ),
+            ),
+            expected_sample=MetricSample(
+                sample_time=DATETIME,
+                metric=999,
+                value=5.0,
+                bounds_set=BoundsSet(),
+                connection=None,
+            ),
+        ),
+        _TestCase(
+            name="invalid_bounds",
+            proto_message=metrics_pb2.MetricSample(
+                sample_time=TIMESTAMP,
+                metric=metric_to_proto(Metric.AC_POWER_ACTIVE),
+                bounds=[bounds_pb2.Bounds(lower=10.0, upper=-10.0)],  # Invalid
+            ),
+            expected_sample=MetricSample(
+                sample_time=DATETIME,
+                metric=Metric.AC_POWER_ACTIVE,
+                value=None,
+                bounds_set=InvalidBoundsSet(
+                    bounds=(InvalidBounds(lower=10.0, upper=-10.0),)
+                ),
+                connection=None,
+            ),
+        ),
+        _TestCase(
+            name="with_connection",
+            proto_message=metrics_pb2.MetricSample(
+                sample_time=TIMESTAMP,
+                metric=metric_to_proto(Metric.AC_POWER_ACTIVE),
+                connection=metrics_pb2.MetricConnection(
+                    category=metric_connection_category_to_proto(
+                        MetricConnectionCategory.BATTERY
+                    ),
+                    name="dc_battery_0",
+                ),
+            ),
+            expected_sample=MetricSample(
+                sample_time=DATETIME,
+                metric=Metric.AC_POWER_ACTIVE,
+                value=None,
+                bounds_set=BoundsSet(),
+                connection=MetricConnection(
+                    category=MetricConnectionCategory.BATTERY, name="dc_battery_0"
+                ),
+            ),
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_from_proto(case: _TestCase) -> None:
+    """Test conversion from protobuf message to MetricSample via the sister."""
+    sample = metric_sample_from_proto(case.proto_message)
+    assert sample == case.expected_sample
+
+
+def test_from_proto_unspecified_metric() -> None:
+    """An unspecified metric is stored as int 0 without warning."""
+    proto = metrics_pb2.MetricSample(
+        sample_time=TIMESTAMP,
+        metric=metrics_pb2.Metric.METRIC_UNSPECIFIED,
+        value=metrics_pb2.MetricValueVariant(
+            simple_metric=metrics_pb2.SimpleMetricValue(value=5.0)
+        ),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        sample = metric_sample_from_proto(proto)
+
+    assert sample.metric == 0
+    assert not isinstance(sample.metric, Metric)

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -26,7 +26,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponentCategory,
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8._electrical_component import (  # noqa: E501
-    _electrical_component_base_from_proto_with_issues,
+    _electrical_component_base_from_proto,
     _ElectricalComponentBaseData,
     _metric_config_bounds_from_proto,
     _operational_mode_to_bools,
@@ -84,18 +84,12 @@ def test_operational_mode_to_bools(
 
 def test_complete(default_component_base_data: _ElectricalComponentBaseData) -> None:
     """Test parsing of a complete base component proto."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.CHP,  # Just to pick a valid category
     )
     proto = base_data_as_proto(base_data)
-    parsed = _electrical_component_base_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    parsed = _electrical_component_base_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert parsed == base_data
 
 
@@ -103,8 +97,6 @@ def test_missing_category_specific_info(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test parsing with missing optional category specific info."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         name="",
         category=ElectricalComponentCategory.UNSPECIFIED,
@@ -116,12 +108,8 @@ def test_missing_category_specific_info(
     proto.ClearField("operational_lifetime")
     proto.ClearField("metric_config_bounds")
 
-    parsed = _electrical_component_base_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    parsed = _electrical_component_base_from_proto(proto)
 
-    assert sorted(major_issues) == sorted(["category is unspecified"])
-    assert not minor_issues
     assert parsed == base_data
 
 
@@ -129,8 +117,6 @@ def test_empty_lifetime_is_unbounded(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """A present but empty protobuf lifetime becomes an unbounded `Lifetime`."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.CHP,
         lifetime=Lifetime(),
@@ -138,12 +124,8 @@ def test_empty_lifetime_is_unbounded(
     proto = base_data_as_proto(base_data)
 
     assert proto.HasField("operational_lifetime")
-    parsed = _electrical_component_base_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    parsed = _electrical_component_base_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert parsed == base_data
 
 
@@ -151,8 +133,6 @@ def test_category_specific_info_mismatch(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test category and category specific info mismatch."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.GRID_CONNECTION_POINT,
         category_specific_info=CategorySpecificInfo(
@@ -165,14 +145,8 @@ def test_category_specific_info_mismatch(
         electrical_components_pb2.BATTERY_TYPE_LI_ION
     )
 
-    parsed = _electrical_component_base_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
-    # Actual message from _electrical_component_base_from_proto_with_issues
-    assert major_issues == [
-        "category_specific_info.kind (battery) does not match the category (grid_connection_point)"
-    ]
-    assert not minor_issues
+    parsed = _electrical_component_base_from_proto(proto)
+
     assert parsed == base_data
 
 
@@ -180,8 +154,6 @@ def test_invalid_lifetime(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test invalid lifetime (start after end)."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.CHP,
         lifetime=InvalidLifetime(
@@ -197,12 +169,8 @@ def test_invalid_lifetime(
         Timestamp(seconds=1696118400)  # 2023-10-01T00:00:00Z
     )
 
-    parsed = _electrical_component_base_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    parsed = _electrical_component_base_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert parsed == base_data
 
 

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_connection.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_connection.py
@@ -3,10 +3,8 @@
 
 """Tests conversion from protobuf messages to ElectricalComponentConnection."""
 
-import logging
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import Mock, patch
 
 import pytest
 from frequenz.api.common.v1alpha8.microgrid import lifetime_pb2
@@ -17,18 +15,16 @@ from google.protobuf import timestamp_pb2
 
 from frequenz.client.common.microgrid import InvalidLifetime, Lifetime
 from frequenz.client.common.microgrid.electrical_components import (
-    ElectricalComponentConnection,
     ElectricalComponentId,
     SelfReferencingElectricalComponentConnection,
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
     electrical_component_connection_from_proto,
-    electrical_component_connection_from_proto_with_issues,
 )
 
 
 @pytest.mark.parametrize(
-    "proto_data, expected_minor_issues",
+    "proto_data",
     [
         pytest.param(
             {
@@ -36,7 +32,6 @@ from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 impor
                 "destination_electrical_component_id": 2,
                 "has_lifetime": True,
             },
-            [],
             id="full",
         ),
         pytest.param(
@@ -45,12 +40,11 @@ from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 impor
                 "destination_electrical_component_id": 2,
                 "has_lifetime": False,
             },
-            [],
             id="no_lifetime",
         ),
     ],
 )
-def test_success(proto_data: dict[str, Any], expected_minor_issues: list[str]) -> None:
+def test_success(proto_data: dict[str, Any]) -> None:
     """Test successful conversion to ElectricalComponentConnection."""
     proto = electrical_components_pb2.ElectricalComponentConnection(
         source_electrical_component_id=proto_data["source_electrical_component_id"],
@@ -67,17 +61,9 @@ def test_success(proto_data: dict[str, Any], expected_minor_issues: list[str]) -
         lifetime.start_timestamp.CopyFrom(start_time)
         proto.operational_lifetime.CopyFrom(lifetime)
 
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
-    connection = electrical_component_connection_from_proto_with_issues(
-        proto,
-        major_issues=major_issues,
-        minor_issues=minor_issues,
-    )
+    connection = electrical_component_connection_from_proto(proto)
 
     assert connection is not None
-    assert not major_issues
-    assert minor_issues == expected_minor_issues
     assert connection.source_id == ElectricalComponentId(
         proto_data["source_electrical_component_id"]
     )
@@ -98,17 +84,11 @@ def test_empty_lifetime_is_unbounded() -> None:
         destination_electrical_component_id=2,
         operational_lifetime=lifetime_pb2.Lifetime(),
     )
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
 
     assert proto.HasField("operational_lifetime")
-    connection = electrical_component_connection_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    connection = electrical_component_connection_from_proto(proto)
 
     assert connection.operational_lifetime == Lifetime()
-    assert not major_issues
-    assert not minor_issues
 
 
 def test_self_referencing_same_ids() -> None:
@@ -117,21 +97,11 @@ def test_self_referencing_same_ids() -> None:
         source_electrical_component_id=1, destination_electrical_component_id=1
     )
 
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
-    conn = electrical_component_connection_from_proto_with_issues(
-        proto,
-        major_issues=major_issues,
-        minor_issues=minor_issues,
-    )
+    conn = electrical_component_connection_from_proto(proto)
 
     assert isinstance(conn, SelfReferencingElectricalComponentConnection)
     assert conn.source_id == ElectricalComponentId(1)
     assert conn.destination_id == ElectricalComponentId(1)
-    assert major_issues == [
-        "self-referencing connection: source and destination are the same (CID1)"
-    ]
-    assert not minor_issues
 
 
 def test_invalid_lifetime() -> None:
@@ -150,11 +120,7 @@ def test_invalid_lifetime() -> None:
         )
     )
 
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
-    connection = electrical_component_connection_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    connection = electrical_component_connection_from_proto(proto)
 
     assert connection is not None
     assert connection.source_id == ElectricalComponentId(1)
@@ -166,59 +132,3 @@ def test_invalid_lifetime() -> None:
     assert connection.operational_lifetime.end_time == datetime(
         2025, 1, 1, tzinfo=timezone.utc
     )
-    assert not major_issues
-    assert not minor_issues
-
-
-@patch(
-    "frequenz.client.common.microgrid.electrical_components.proto.v1alpha8."
-    "_electrical_component_connection."
-    "electrical_component_connection_from_proto_with_issues",
-    autospec=True,
-)
-def test_issues_logging(
-    mock_from_proto_with_issues: Mock, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test collection and logging of issues during proto conversion."""
-    caplog.set_level("DEBUG")  # Ensure we capture DEBUG level messages
-
-    fake_connection = ElectricalComponentConnection(
-        source_id=ElectricalComponentId(1),
-        destination_id=ElectricalComponentId(2),
-    )
-
-    def _fake_from_proto_with_issues(
-        _: electrical_components_pb2.ElectricalComponentConnection,
-        *,
-        major_issues: list[str],
-        minor_issues: list[str],
-    ) -> ElectricalComponentConnection:
-        """Fake function to simulate conversion and logging."""
-        major_issues.append("fake major issue")
-        minor_issues.append("fake minor issue")
-        return fake_connection
-
-    mock_from_proto_with_issues.side_effect = _fake_from_proto_with_issues
-
-    mock_proto = Mock(
-        name="proto", spec=electrical_components_pb2.ElectricalComponentConnection
-    )
-    connection = electrical_component_connection_from_proto(mock_proto)
-
-    assert connection is fake_connection
-    assert caplog.record_tuples == [
-        (
-            "frequenz.client.common.microgrid.electrical_components.proto.v1alpha8."
-            "_electrical_component_connection",
-            logging.WARNING,
-            "Found issues in electrical component connection: fake major issue | "
-            f"Protobuf message:\n{mock_proto}",
-        ),
-        (
-            "frequenz.client.common.microgrid.electrical_components.proto.v1alpha8."
-            "_electrical_component_connection",
-            logging.DEBUG,
-            "Found minor issues in electrical component connection: fake minor issue | "
-            f"Protobuf message:\n{mock_proto}",
-        ),
-    ]

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
@@ -3,9 +3,6 @@
 
 """Tests for protobuf conversion of simple electrical components."""
 
-import logging
-from unittest.mock import Mock, patch
-
 import pytest
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
@@ -38,7 +35,6 @@ from frequenz.client.common.microgrid.electrical_components import (
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
     electrical_component_class_to_proto,
     electrical_component_from_proto,
-    electrical_component_from_proto_with_issues,
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8._electrical_component import (  # noqa: E501
     _ElectricalComponentBaseData,
@@ -49,16 +45,10 @@ from .conftest import assert_base_data, base_data_as_proto
 
 def test_unspecified(default_component_base_data: _ElectricalComponentBaseData) -> None:
     """Test ElectricalComponent with unspecified category."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     proto = base_data_as_proto(default_component_base_data)
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    component = electrical_component_from_proto(proto)
 
-    assert major_issues == ["category is unspecified"]
-    assert not minor_issues
     assert isinstance(component, UnspecifiedElectricalComponent)
     assert_base_data(default_component_base_data, component)
     assert electrical_component_class_to_proto(component) == (
@@ -71,17 +61,11 @@ def test_unrecognized(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test ElectricalComponent with unrecognized category."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(category=999)
     proto = base_data_as_proto(base_data)
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    component = electrical_component_from_proto(proto)
 
-    assert major_issues == ["category 999 is unrecognized"]
-    assert not minor_issues
     assert isinstance(component, UnrecognizedElectricalComponent)
     assert_base_data(base_data, component)
     assert electrical_component_class_to_proto(component) == (999, None)
@@ -91,8 +75,6 @@ def test_category_mismatch(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test mismatched category handling for category GRID and battery info."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=1,  # GRID_CONNECTION_POINT
         category_specific_info=CategorySpecificInfo(
@@ -105,15 +87,8 @@ def test_category_mismatch(
         electrical_components_pb2.BATTERY_TYPE_LI_ION
     )
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
-    # The actual message from electrical_component_from_proto_with_issues via
-    # _component_base_from_proto_with_issues
-    assert major_issues == [
-        "category_specific_info.kind (battery) does not match the category (grid_connection_point)"
-    ]
-    assert not minor_issues
+    component = electrical_component_from_proto(proto)
+
     assert isinstance(component, MismatchedCategoryElectricalComponent)
     assert_base_data(base_data, component)
     assert component.category_specific_info == CategorySpecificInfo(
@@ -170,17 +145,11 @@ def test_trivial(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test component types that don't need special handling."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    component = electrical_component_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert isinstance(component, component_class)
     assert not isinstance(component, UnrecognizedElectricalComponent)
     assert_base_data(base_data, component)
@@ -194,8 +163,6 @@ def test_power_transformer(
     secondary: float | None,
 ) -> None:
     """Test PowerTransformer component."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.POWER_TRANSFORMER
     )
@@ -206,12 +173,8 @@ def test_power_transformer(
     if secondary is not None:
         proto.category_specific_info.power_transformer.secondary = secondary
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    component = electrical_component_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert isinstance(component, PowerTransformer)
     assert_base_data(base_data, component)
     assert component.primary_voltage == (
@@ -228,8 +191,6 @@ def test_grid(
     rated_fuse_current: int | None,
 ) -> None:
     """Test GridConnectionPoint component with default values."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.GRID_CONNECTION_POINT
     )
@@ -240,62 +201,10 @@ def test_grid(
             rated_fuse_current
         )
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
+    component = electrical_component_from_proto(proto)
 
-    assert not major_issues
-    assert not minor_issues
     assert isinstance(component, GridConnectionPoint)
     assert_base_data(base_data, component)
     assert component.rated_fuse_current == (
         rated_fuse_current if rated_fuse_current is not None else 0
     )
-
-
-@patch(
-    "frequenz.client.common.microgrid.electrical_components.proto.v1alpha8."
-    "_electrical_component.electrical_component_from_proto_with_issues",
-    autospec=True,
-)
-def test_issues_logging(
-    mock_from_proto_with_issues: Mock, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test collection and logging of issues during proto conversion."""
-    caplog.set_level("DEBUG")  # Ensure we capture DEBUG level messages
-
-    mock_component = Mock(name="component", spec=ElectricalComponent)
-
-    def _fake_from_proto_with_issues(
-        _: electrical_components_pb2.ElectricalComponent,
-        *,
-        major_issues: list[str],
-        minor_issues: list[str],
-    ) -> ElectricalComponent:
-        """Fake function to simulate conversion and logging."""
-        major_issues.append("fake major issue")
-        minor_issues.append("fake minor issue")
-        return mock_component
-
-    mock_from_proto_with_issues.side_effect = _fake_from_proto_with_issues
-
-    mock_proto = Mock(name="proto", spec=electrical_components_pb2.ElectricalComponent)
-    component = electrical_component_from_proto(mock_proto)
-
-    assert component is mock_component
-    assert caplog.record_tuples == [
-        (
-            "frequenz.client.common.microgrid.electrical_components.proto"
-            ".v1alpha8._electrical_component",
-            logging.WARNING,
-            "Found issues in electrical component: fake major issue | "
-            f"Protobuf message:\n{mock_proto}",
-        ),
-        (
-            "frequenz.client.common.microgrid.electrical_components.proto"
-            ".v1alpha8._electrical_component",
-            logging.DEBUG,
-            "Found minor issues in electrical component: fake minor issue | "
-            f"Protobuf message:\n{mock_proto}",
-        ),
-    ]

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_with_type.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_with_type.py
@@ -30,7 +30,7 @@ from frequenz.client.common.microgrid.electrical_components import (
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8 import (
     electrical_component_class_to_proto,
-    electrical_component_from_proto_with_issues,
+    electrical_component_from_proto,
 )
 from frequenz.client.common.microgrid.electrical_components.proto.v1alpha8._electrical_component import (  # noqa: E501
     _ElectricalComponentBaseData,
@@ -40,30 +40,26 @@ from .conftest import assert_base_data, base_data_as_proto
 
 
 @pytest.mark.parametrize(
-    "battery_class, pb_battery_type, expected_major_issues",
+    "battery_class, pb_battery_type",
     [
         pytest.param(
             LiIonBattery,
             electrical_components_pb2.BATTERY_TYPE_LI_ION,
-            [],
             id="LI_ION",
         ),
         pytest.param(
             NaIonBattery,
             electrical_components_pb2.BATTERY_TYPE_NA_ION,
-            [],
             id="NA_ION",
         ),
         pytest.param(
             UnspecifiedBattery,
             electrical_components_pb2.BATTERY_TYPE_UNSPECIFIED,
-            ["battery type is unspecified"],
             id="UNSPECIFIED",
         ),
         pytest.param(
             UnrecognizedBattery,
             999,
-            ["battery type 999 is unrecognized"],
             id="UNRECOGNIZED",
         ),
     ],
@@ -72,22 +68,16 @@ def test_battery(
     default_component_base_data: _ElectricalComponentBaseData,
     battery_class: type[Battery],
     pb_battery_type: int,
-    expected_major_issues: list[str],
 ) -> None:
     """Test battery component."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.BATTERY
     )
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.battery.type = pb_battery_type  # type: ignore[assignment]
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
-    assert major_issues == expected_major_issues
-    assert not minor_issues
+    component = electrical_component_from_proto(proto)
+
     assert isinstance(component, Battery)
     assert isinstance(component, battery_class)
     assert_base_data(base_data, component)
@@ -98,36 +88,31 @@ def test_battery(
 
 
 @pytest.mark.parametrize(
-    "ev_charger_class, pb_ev_charger_type, expected_major_issues",
+    "ev_charger_class, pb_ev_charger_type",
     [
         pytest.param(
             AcEvCharger,
             electrical_components_pb2.EV_CHARGER_TYPE_AC,
-            [],
             id="AC",
         ),
         pytest.param(
             DcEvCharger,
             electrical_components_pb2.EV_CHARGER_TYPE_DC,
-            [],
             id="DC",
         ),
         pytest.param(
             HybridEvCharger,
             electrical_components_pb2.EV_CHARGER_TYPE_HYBRID,
-            [],
             id="HYBRID",
         ),
         pytest.param(
             UnspecifiedEvCharger,
             electrical_components_pb2.EV_CHARGER_TYPE_UNSPECIFIED,
-            ["ev_charger type is unspecified"],
             id="UNSPECIFIED",
         ),
         pytest.param(
             UnrecognizedEvCharger,
             999,
-            ["ev_charger type 999 is unrecognized"],
             id="UNRECOGNIZED",
         ),
     ],
@@ -136,22 +121,16 @@ def test_ev_charger(
     default_component_base_data: _ElectricalComponentBaseData,
     ev_charger_class: type[EvCharger],
     pb_ev_charger_type: int,
-    expected_major_issues: list[str],
 ) -> None:
     """Test EV Charger component."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.EV_CHARGER
     )
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.ev_charger.type = pb_ev_charger_type  # type: ignore[assignment]
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
-    assert major_issues == expected_major_issues
-    assert not minor_issues
+    component = electrical_component_from_proto(proto)
+
     assert isinstance(component, EvCharger)
     assert isinstance(component, ev_charger_class)
     assert_base_data(base_data, component)
@@ -162,36 +141,31 @@ def test_ev_charger(
 
 
 @pytest.mark.parametrize(
-    "inverter_class, pb_inverter_type, expected_major_issues",
+    "inverter_class, pb_inverter_type",
     [
         pytest.param(
             BatteryInverter,
             electrical_components_pb2.INVERTER_TYPE_BATTERY,
-            [],
             id="BATTERY",
         ),
         pytest.param(
             PvInverter,
             electrical_components_pb2.INVERTER_TYPE_PV,
-            [],
             id="PV",
         ),
         pytest.param(
             HybridInverter,
             electrical_components_pb2.INVERTER_TYPE_HYBRID,
-            [],
             id="HYBRID",
         ),
         pytest.param(
             UnspecifiedInverter,
             electrical_components_pb2.INVERTER_TYPE_UNSPECIFIED,
-            ["inverter type is unspecified"],
             id="UNSPECIFIED",
         ),
         pytest.param(
             UnrecognizedInverter,
             999,
-            ["inverter type 999 is unrecognized"],
             id="UNRECOGNIZED",
         ),
     ],
@@ -200,22 +174,16 @@ def test_inverter(
     default_component_base_data: _ElectricalComponentBaseData,
     inverter_class: type[Inverter],
     pb_inverter_type: int,
-    expected_major_issues: list[str],
 ) -> None:
     """Test inverter component."""
-    major_issues: list[str] = []
-    minor_issues: list[str] = []
     base_data = default_component_base_data._replace(
         category=ElectricalComponentCategory.INVERTER
     )
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.inverter.type = pb_inverter_type  # type: ignore[assignment]
 
-    component = electrical_component_from_proto_with_issues(
-        proto, major_issues=major_issues, minor_issues=minor_issues
-    )
-    assert major_issues == expected_major_issues
-    assert not minor_issues
+    component = electrical_component_from_proto(proto)
+
     assert isinstance(component, Inverter)
     assert isinstance(component, inverter_class)
     assert_base_data(base_data, component)


### PR DESCRIPTION
This PR deprecates and removes all the remaining instances of `_with_issues()` functions, that should now have an anternative that reports issues via the type system. This should finalize #239 for the v0.4.1 release.
