### PR TITLE
Preserve protobuf field names in `CategorySpecificInfo.fields`

### DIFF
--- a/src/frequenz/client/common/microgrid/electrical_components/_category_specific_info.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/_category_specific_info.py
@@ -34,5 +34,7 @@ class CategorySpecificInfo:
     )
     """The leftover fields not translated into typed attributes.
 
-    The keys are the protobuf field names and the values their decoded content.
+    The keys are the protobuf field names — the ``snake_case`` spelling from
+    the ``.proto`` definition (e.g. ``"rated_fuse_current"``), and the values
+    their decoded content.
     """

--- a/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
+++ b/src/frequenz/client/common/microgrid/electrical_components/proto/v1alpha8/_electrical_component.py
@@ -965,6 +965,7 @@ def _electrical_component_base_from_proto(
                         message.category_specific_info, category_specific_info_kind
                     ),
                     always_print_fields_with_no_presence=True,
+                    preserving_proto_field_name=True,
                 ),
             )
 
@@ -1141,7 +1142,7 @@ def electrical_component_from_proto(
                 )
             case ElectricalComponentCategory.GRID_CONNECTION_POINT:
                 grid_info = _leftover_info(
-                    base_data.category_specific_info, "ratedFuseCurrent"
+                    base_data.category_specific_info, "rated_fuse_current"
                 )
                 rated_fuse_current = (
                     message.category_specific_info.grid_connection_point.rated_fuse_current

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
@@ -208,3 +208,9 @@ def test_grid(
     assert component.rated_fuse_current == (
         rated_fuse_current if rated_fuse_current is not None else 0
     )
+    if rated_fuse_current is None:
+        assert component.category_specific_info is None
+    else:
+        assert component.category_specific_info == CategorySpecificInfo(
+            kind="grid_connection_point", fields={}
+        )

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
@@ -116,6 +116,31 @@ def test_unrecognized_category_preserves_info(
     )
 
 
+def test_unrecognized_category_grid_info_keeps_snake_case_keys(
+    default_component_base_data: _ElectricalComponentBaseData,
+) -> None:
+    """Leftover multiword fields expose their protobuf ``snake_case`` names.
+
+    Regression test for a grid connection point carried by an unrecognized
+    category: the whole info is preserved verbatim, and a caller following the
+    documented contract reads ``fields["rated_fuse_current"]`` (the protobuf
+    field name) rather than the protobuf JSON ``lowerCamelCase`` spelling.
+    """
+    base_data = default_component_base_data._replace(category=999)
+    proto = base_data_as_proto(base_data)
+    proto.category_specific_info.grid_connection_point.rated_fuse_current = 23
+
+    component = electrical_component_from_proto(proto)
+
+    assert isinstance(component, UnrecognizedElectricalComponent)
+    info = component.category_specific_info
+    assert info == CategorySpecificInfo(
+        kind="grid_connection_point", fields={"rated_fuse_current": 23}
+    )
+    assert info is not None
+    assert info.fields["rated_fuse_current"] == 23
+
+
 def test_unrecognized_type_shows_in_repr(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:


### PR DESCRIPTION
`electrical_component_from_proto` builds `CategorySpecificInfo.fields` with `MessageToDict`, which defaults to protobuf JSON `lowerCamelCase` keys. That contradicted the field's documented contract — "the keys are the protobuf field names" — for every multiword field: a grid connection point's `rated_fuse_current` was exposed as `ratedFuseCurrent`, so a forward-compatible caller reading the documented `fields["rated_fuse_current"]` off an unrecognized or mismatched component got a `KeyError`.

Pass `preserving_proto_field_name=True` so the keys are the `snake_case` `.proto` field names, matching both the docstring and the typed attributes (e.g. `GridConnectionPoint.rated_fuse_current`). The recognized grid connection point strips its translated field from the leftover `fields`, so update that key from `"ratedFuseCurrent"` to `"rated_fuse_current"` too; otherwise the newly snake_cased key would leak back into `fields`.
