### PR TITLE
Suppress spurious deprecation warnings in electrical component tests

### DIFF
--- a/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/conftest.py
@@ -3,6 +3,7 @@
 
 """Fixtures and utilities for testing electrical component protobuf conversion."""
 
+import warnings
 from datetime import datetime, timezone
 
 import pytest
@@ -52,12 +53,15 @@ def default_component_base_data(
     component_id: ElectricalComponentId, microgrid_id: MicrogridId
 ) -> _ElectricalComponentBaseData:
     """Provide a fixture for common component fields."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.UNSPECIFIED
     return _ElectricalComponentBaseData(
         component_id=component_id,
         microgrid_id=microgrid_id,
         name=DEFAULT_NAME,
         model=DEFAULT_MODEL,
-        category=ElectricalComponentCategory.UNSPECIFIED,
+        category=category,
         lifetime=DEFAULT_LIFETIME,
         metric_config_bounds={
             Metric.AC_ENERGY_ACTIVE: BoundsSet(bounds=(Bounds(lower=0, upper=100),))

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_base.py
@@ -4,6 +4,7 @@
 """Tests for protobuf conversion of the base/common part of electrical components."""
 
 import math
+import warnings
 from datetime import timezone
 
 import pytest
@@ -84,9 +85,10 @@ def test_operational_mode_to_bools(
 
 def test_complete(default_component_base_data: _ElectricalComponentBaseData) -> None:
     """Test parsing of a complete base component proto."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.CHP,  # Just to pick a valid category
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.CHP  # Just to pick a valid category
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     parsed = _electrical_component_base_from_proto(proto)
 
@@ -97,9 +99,12 @@ def test_missing_category_specific_info(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test parsing with missing optional category specific info."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.UNSPECIFIED
     base_data = default_component_base_data._replace(
         name="",
-        category=ElectricalComponentCategory.UNSPECIFIED,
+        category=category,
         lifetime=Lifetime(),
         metric_config_bounds={},
         category_specific_info=None,
@@ -117,8 +122,11 @@ def test_empty_lifetime_is_unbounded(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """A present but empty protobuf lifetime becomes an unbounded `Lifetime`."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.CHP
     base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.CHP,
+        category=category,
         lifetime=Lifetime(),
     )
     proto = base_data_as_proto(base_data)
@@ -133,8 +141,11 @@ def test_category_specific_info_mismatch(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test category and category specific info mismatch."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.GRID_CONNECTION_POINT
     base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.GRID_CONNECTION_POINT,
+        category=category,
         category_specific_info=CategorySpecificInfo(
             kind="battery", fields={"type": "BATTERY_TYPE_LI_ION"}
         ),
@@ -154,8 +165,11 @@ def test_invalid_lifetime(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Test invalid lifetime (start after end)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.CHP
     base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.CHP,
+        category=category,
         lifetime=InvalidLifetime(
             start_time=Timestamp(seconds=1696204800).ToDatetime(tzinfo=timezone.utc),
             end_time=Timestamp(seconds=1696118400).ToDatetime(tzinfo=timezone.utc),
@@ -190,18 +204,21 @@ def _metric_bound(
 
 def test_metric_config_bounds_stores_unspecified_as_int() -> None:
     """Test UNSPECIFIED metric bounds load as plain int key 0."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        unspecified = Metric.UNSPECIFIED
     message = [
-        _metric_bound(int(Metric.UNSPECIFIED.value), 0.0, 1.0),
+        _metric_bound(int(unspecified.value), 0.0, 1.0),
         _metric_bound(_UNKNOWN_METRIC_INT, 2.0, 3.0),
         _metric_bound(int(Metric.DC_VOLTAGE.value), 4.0, 5.0),
     ]
 
     parsed = _metric_config_bounds_from_proto(message)
 
-    assert parsed[int(Metric.UNSPECIFIED.value)] == BoundsSet(
+    assert parsed[int(unspecified.value)] == BoundsSet(
         bounds=(Bounds(lower=0.0, upper=1.0),)
     )
-    assert Metric.UNSPECIFIED not in parsed
+    assert unspecified not in parsed
     assert parsed[_UNKNOWN_METRIC_INT] == BoundsSet(
         bounds=(Bounds(lower=2.0, upper=3.0),)
     )

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_simple.py
@@ -3,6 +3,8 @@
 
 """Tests for protobuf conversion of simple electrical components."""
 
+import warnings
+
 import pytest
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
@@ -98,9 +100,9 @@ def test_category_mismatch(
     assert electrical_component_class_to_proto(component) == (1, None)
 
 
-@pytest.mark.parametrize(
-    "category,component_class",
-    [
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    _TRIVIAL_CASES = [
         pytest.param(ElectricalComponentCategory.BREAKER, Breaker, id="Breaker"),
         pytest.param(
             ElectricalComponentCategory.CAPACITOR_BANK,
@@ -137,8 +139,10 @@ def test_category_mismatch(
         pytest.param(
             ElectricalComponentCategory.WIND_TURBINE, WindTurbine, id="WindTurbine"
         ),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("category,component_class", _TRIVIAL_CASES)
 def test_trivial(
     category: ElectricalComponentCategory,
     component_class: type[ElectricalComponent],
@@ -163,9 +167,10 @@ def test_power_transformer(
     secondary: float | None,
 ) -> None:
     """Test PowerTransformer component."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.POWER_TRANSFORMER
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.POWER_TRANSFORMER
+    base_data = default_component_base_data._replace(category=category)
 
     proto = base_data_as_proto(base_data)
     if primary is not None:
@@ -191,9 +196,10 @@ def test_grid(
     rated_fuse_current: int | None,
 ) -> None:
     """Test GridConnectionPoint component with default values."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.GRID_CONNECTION_POINT
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.GRID_CONNECTION_POINT
+    base_data = default_component_base_data._replace(category=category)
 
     proto = base_data_as_proto(base_data)
     if rated_fuse_current is not None:

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_with_type.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_electrical_component_with_type.py
@@ -3,6 +3,8 @@
 
 """Tests for protobuf conversion of components with a type."""
 
+import warnings
+
 import pytest
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
@@ -70,9 +72,10 @@ def test_battery(
     pb_battery_type: int,
 ) -> None:
     """Test battery component."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.BATTERY
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.BATTERY
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.battery.type = pb_battery_type  # type: ignore[assignment]
 
@@ -123,9 +126,10 @@ def test_ev_charger(
     pb_ev_charger_type: int,
 ) -> None:
     """Test EV Charger component."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.EV_CHARGER
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.EV_CHARGER
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.ev_charger.type = pb_ev_charger_type  # type: ignore[assignment]
 
@@ -176,9 +180,10 @@ def test_inverter(
     pb_inverter_type: int,
 ) -> None:
     """Test inverter component."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.INVERTER
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.INVERTER
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.inverter.type = pb_inverter_type  # type: ignore[assignment]
 

--- a/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
+++ b/tests/microgrid/electrical_components/proto/v1alpha8/test_raw_storage.py
@@ -32,9 +32,10 @@ def _li_ion_battery(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> LiIonBattery:
     """Build a `LiIonBattery` through the protobuf converter."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.BATTERY
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.BATTERY
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.battery.type = (
         electrical_components_pb2.BATTERY_TYPE_LI_ION
@@ -177,9 +178,10 @@ def test_from_proto_emits_no_deprecation_warning(
     default_component_base_data: _ElectricalComponentBaseData,
 ) -> None:
     """Converting a protobuf message must not emit a `DeprecationWarning`."""
-    base_data = default_component_base_data._replace(
-        category=ElectricalComponentCategory.BATTERY
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        category = ElectricalComponentCategory.BATTERY
+    base_data = default_component_base_data._replace(category=category)
     proto = base_data_as_proto(base_data)
     proto.category_specific_info.battery.type = (
         electrical_components_pb2.BATTERY_TYPE_LI_ION


### PR DESCRIPTION
The v1alpha8 electrical-component protobuf tests build their fixtures and parametrized cases from `ElectricalComponentCategory` members (and, in the metric-bounds test, `Metric.UNSPECIFIED`). Both enums are deprecated, so every member access raises a `DeprecationWarning` via `frequenz.core.enum`. The tests genuinely need those deprecated categories -- they exercise the protobuf `category` field the wrappers translate -- so the warnings are noise, not signal. With pytest's `once::DeprecationWarning` filter the run printed 123 of them.

Capture each deprecated member inside a minimal `warnings.catch_warnings()` / `warnings.simplefilter("ignore", DeprecationWarning)` block and reuse the captured value, so only the deprecated attribute access is suppressed and nothing around it. `test_trivial` reads its members at import time through the `parametrize` decorator, so its case list moves into a module-level suppression block (`_TRIVIAL_CASES`). This follows the pattern already used in `test_enum_deprecation.py`, leaves the intentional `pytest.deprecated_call()` / `simplefilter("error", ...)` tests untouched, and takes the suite from 123 warnings to none.
